### PR TITLE
feat: add tap test in infra and info assurance patterns #44

### DIFF
--- a/lib/pattern/info-assurance-controls/README.md
+++ b/lib/pattern/info-assurance-controls/README.md
@@ -51,3 +51,18 @@ To execute test and ensure that `surveilr` is functioning correctly:
 
 The `-A` flag provides all necessary permissions for the tests to run, including
 file system access and network permissions.
+
+## How to Run the Tap Tests
+
+### RUN THIS TEST this using CLI
+
+`rm -f tap.sql &&  deno run -A ./tap.sql.ts > tap.sql`
+
+This will generate a tap.sql file from tap.sql.ts
+
+`cat tap.sql | sqlite3 resource-surveillance.sqlite.db && sqlite3 resource-surveillance.sqlite.db -cmd "
+SELECT * FROM synthetic_test_suite;"`
+
+This script demonstrates how to create a Test Anything Protocol (TAP) report
+using SQLite, following TAP version 14. It includes multiple test cases, and
+subtests are formatted with indentation per TAP 14's subtest style.

--- a/lib/pattern/info-assurance-controls/tap.sql
+++ b/lib/pattern/info-assurance-controls/tap.sql
@@ -1,0 +1,63 @@
+DROP VIEW IF EXISTS "synthetic_test_suite";
+CREATE VIEW "synthetic_test_suite" AS
+    WITH
+        tap_version AS (SELECT 'TAP version 14' AS tap_result),
+        tap_plan AS (SELECT '1..6' AS tap_result),
+        -- 0: Check if a view 'control_regimes' exists
+"Check if a view 'control_regimes' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'control_regimes'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 0 ' || ('View "control_regimes" exists in the DB') ELSE 'not ok 0 ' || ('View "control_regimes" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 1: Ensure 'control_regimes' view has values 
+"Ensure 'control_regimes' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS control_regimes_count FROM control_regimes
+  )
+  SELECT CASE WHEN control_regimes_count > 0 THEN 'ok 1 ' || ('control_regimes_count is greater than 0') ELSE 'not ok 1 ' || ('control_regimes_count should be greater than 0, is ' || control_regimes_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 2: Check if a view 'control_group' exists
+"Check if a view 'control_group' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'control_group'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 2 ' || ('View "control_group" exists in the DB') ELSE 'not ok 2 ' || ('View "control_group" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 3: Ensure 'control_group' view has values 
+"Ensure 'control_group' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS control_group_count FROM control_group
+  )
+  SELECT CASE WHEN control_group_count > 0 THEN 'ok 3 ' || ('control_group_count is greater than 0') ELSE 'not ok 3 ' || ('control_group_count should be greater than 0, is ' || control_group_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 4: Check if a view 'control' exists
+"Check if a view 'control' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'control'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 4 ' || ('View "control" exists in the DB') ELSE 'not ok 4 ' || ('View "control" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 5: Ensure 'control' view has values 
+"Ensure 'control' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS control_count FROM control
+  )
+  SELECT CASE WHEN control_count > 0 THEN 'ok 5 ' || ('control_count is greater than 0') ELSE 'not ok 5 ' || ('control_count should be greater than 0, is ' || control_count || ' instead') END AS tap_result FROM test_case
+)
+    SELECT tap_result FROM tap_version
+    UNION ALL
+    SELECT tap_result FROM tap_plan
+    UNION ALL
+    SELECT tap_result FROM "Check if a view 'control_regimes' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'control_regimes' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'control_group' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'control_group' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'control' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'control' view has values ";
+SELECT * FROM synthetic_test_suite;

--- a/lib/pattern/info-assurance-controls/tap.sql.ts
+++ b/lib/pattern/info-assurance-controls/tap.sql.ts
@@ -1,0 +1,67 @@
+import { tapNB } from "../../std/notebook/mod.ts";
+type TestCaseContext = tapNB.TestCaseContext;
+export class SyntheticTestSuite extends tapNB.TestSuiteNotebook {
+    // any method that ends in DDL, SQL, DML, or DQL will be "arbitrary SQL"
+    // and included in the SQL stream before all the test cases
+
+    "Check if a view 'control_regimes' exists"(ctx: TestCaseContext) {
+        const viewName = "control_regimes";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'control_regimes' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"control_regimes_count">(ctx)`
+            SELECT COUNT(*) AS control_regimes_count FROM control_regimes`
+            .greaterThan("control_regimes_count", 0);
+    }
+
+    "Check if a view 'control_group' exists"(ctx: TestCaseContext) {
+        const viewName = "control_group";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'control_group' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"control_group_count">(ctx)`
+            SELECT COUNT(*) AS control_group_count FROM control_group`
+            .greaterThan("control_group_count", 0);
+    }
+
+    "Check if a view 'control' exists"(ctx: TestCaseContext) {
+        const viewName = "control";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'control' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"control_count">(ctx)`
+            SELECT COUNT(*) AS control_count FROM control`
+            .greaterThan("control_count", 0);
+    }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    const SQL = await tapNB.TestSuiteNotebook.SQL(
+        new SyntheticTestSuite("synthetic_test_suite"),
+    );
+
+    console.log(SQL.join("\n"));
+    console.log(`SELECT * FROM synthetic_test_suite;`);
+}

--- a/lib/pattern/info-assurance-policies/README.md
+++ b/lib/pattern/info-assurance-policies/README.md
@@ -54,3 +54,18 @@ To execute test and ensure that `surveilr` is functioning correctly:
 
 The `-A` flag provides all necessary permissions for the tests to run, including
 file system access and network permissions.
+
+## How to Run the Tap Tests
+
+### RUN THIS TEST this using CLI
+
+`rm -f tap.sql &&  deno run -A ./tap.sql.ts > tap.sql`
+
+This will generate a tap.sql file from tap.sql.ts
+
+`cat tap.sql | sqlite3 resource-surveillance.sqlite.db && sqlite3 resource-surveillance.sqlite.db -cmd "
+SELECT * FROM synthetic_test_suite;"`
+
+This script demonstrates how to create a Test Anything Protocol (TAP) report
+using SQLite, following TAP version 14. It includes multiple test cases, and
+subtests are formatted with indentation per TAP 14's subtest style.

--- a/lib/pattern/info-assurance-policies/tap.sql
+++ b/lib/pattern/info-assurance-policies/tap.sql
@@ -1,0 +1,297 @@
+DROP VIEW IF EXISTS "synthetic_test_suite";
+CREATE VIEW "synthetic_test_suite" AS
+    WITH
+        tap_version AS (SELECT 'TAP version 14' AS tap_result),
+        tap_plan AS (SELECT '1..32' AS tap_result),
+        -- 0: Check if a view 'policy_dashboard' exists
+"Check if a view 'policy_dashboard' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'policy_dashboard'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 0 ' || ('View "policy_dashboard" exists in the DB') ELSE 'not ok 0 ' || ('View "policy_dashboard" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 1: Ensure 'policy_dashboard' view has values 
+"Ensure 'policy_dashboard' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS policy_dashboard_count FROM policy_dashboard
+  )
+  SELECT CASE WHEN policy_dashboard_count > 0 THEN 'ok 1 ' || ('policy_dashboard_count is greater than 0') ELSE 'not ok 1 ' || ('policy_dashboard_count should be greater than 0, is ' || policy_dashboard_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 2: Check if a view 'policy_detail' exists
+"Check if a view 'policy_detail' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'policy_detail'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 2 ' || ('View "policy_detail" exists in the DB') ELSE 'not ok 2 ' || ('View "policy_detail" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 3: Ensure 'policy_detail' view has values 
+"Ensure 'policy_detail' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS policy_detail_count FROM policy_detail
+  )
+  SELECT CASE WHEN policy_detail_count > 0 THEN 'ok 3 ' || ('policy_detail_count is greater than 0') ELSE 'not ok 3 ' || ('policy_detail_count should be greater than 0, is ' || policy_detail_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 4: Check if a view 'policy_list' exists
+"Check if a view 'policy_list' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'policy_list'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 4 ' || ('View "policy_list" exists in the DB') ELSE 'not ok 4 ' || ('View "policy_list" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 5: Ensure 'policy_list' view has values 
+"Ensure 'policy_list' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS policy_list_count FROM policy_list
+  )
+  SELECT CASE WHEN policy_list_count > 0 THEN 'ok 5 ' || ('policy_list_count is greater than 0') ELSE 'not ok 5 ' || ('policy_list_count should be greater than 0, is ' || policy_list_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 6: Check if a view 'vigetallviews' exists
+"Check if a view 'vigetallviews' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vigetallviews'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 6 ' || ('View "vigetallviews" exists in the DB') ELSE 'not ok 6 ' || ('View "vigetallviews" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 7: Ensure 'vigetallviews' view has values 
+"Ensure 'vigetallviews' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vigetallviews_count FROM vigetallviews
+  )
+  SELECT CASE WHEN vigetallviews_count > 0 THEN 'ok 7 ' || ('vigetallviews_count is greater than 0') ELSE 'not ok 7 ' || ('vigetallviews_count should be greater than 0, is ' || vigetallviews_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 8: Check if a view 'viup_time' exists
+"Check if a view 'viup_time' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viup_time'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 8 ' || ('View "viup_time" exists in the DB') ELSE 'not ok 8 ' || ('View "viup_time" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 9: Ensure 'viup_time' view has values 
+"Ensure 'viup_time' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viup_time_count FROM viup_time
+  )
+  SELECT CASE WHEN viup_time_count > 0 THEN 'ok 9 ' || ('viup_time_count is greater than 0') ELSE 'not ok 9 ' || ('viup_time_count should be greater than 0, is ' || viup_time_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 10: Check if a view 'viLog' exists
+"Check if a view 'viLog' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viLog'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 10 ' || ('View "viLog" exists in the DB') ELSE 'not ok 10 ' || ('View "viLog" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 11: Ensure 'viLog' view has values 
+"Ensure 'viLog' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viLog_count FROM viLog
+  )
+  SELECT CASE WHEN viLog_count > 0 THEN 'ok 11 ' || ('viLog_count is greater than 0') ELSE 'not ok 11 ' || ('viLog_count should be greater than 0, is ' || viLog_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 12: Check if a view 'viencrypted_passwords' exists
+"Check if a view 'viencrypted_passwords' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viencrypted_passwords'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 12 ' || ('View "viencrypted_passwords" exists in the DB') ELSE 'not ok 12 ' || ('View "viencrypted_passwords" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 13: Ensure 'viencrypted_passwords' view has values 
+"Ensure 'viencrypted_passwords' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viencrypted_passwords_count FROM viencrypted_passwords
+  )
+  SELECT CASE WHEN viencrypted_passwords_count > 0 THEN 'ok 13 ' || ('viencrypted_passwords_count is greater than 0') ELSE 'not ok 13 ' || ('viencrypted_passwords_count should be greater than 0, is ' || viencrypted_passwords_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 14: Check if a view 'vinetwork_log' exists
+"Check if a view 'vinetwork_log' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vinetwork_log'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 14 ' || ('View "vinetwork_log" exists in the DB') ELSE 'not ok 14 ' || ('View "vinetwork_log" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 15: Ensure 'vinetwork_log' view has values 
+"Ensure 'vinetwork_log' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vinetwork_log_count FROM vinetwork_log
+  )
+  SELECT CASE WHEN vinetwork_log_count > 0 THEN 'ok 15 ' || ('vinetwork_log_count is greater than 0') ELSE 'not ok 15 ' || ('vinetwork_log_count should be greater than 0, is ' || vinetwork_log_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 16: Check if a view 'vissl_certificate' exists
+"Check if a view 'vissl_certificate' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vissl_certificate'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 16 ' || ('View "vissl_certificate" exists in the DB') ELSE 'not ok 16 ' || ('View "vissl_certificate" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 17: Ensure 'vissl_certificate' view has values 
+"Ensure 'vissl_certificate' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vissl_certificate_count FROM vissl_certificate
+  )
+  SELECT CASE WHEN vissl_certificate_count > 0 THEN 'ok 17 ' || ('vissl_certificate_count is greater than 0') ELSE 'not ok 17 ' || ('vissl_certificate_count should be greater than 0, is ' || vissl_certificate_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 18: Check if a view 'vistorage_available' exists
+"Check if a view 'vistorage_available' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vistorage_available'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 18 ' || ('View "vistorage_available" exists in the DB') ELSE 'not ok 18 ' || ('View "vistorage_available" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 19: Ensure 'vistorage_available' view has values 
+"Ensure 'vistorage_available' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vistorage_available_count FROM vistorage_available
+  )
+  SELECT CASE WHEN vistorage_available_count > 0 THEN 'ok 19 ' || ('vistorage_available_count is greater than 0') ELSE 'not ok 19 ' || ('vistorage_available_count should be greater than 0, is ' || vistorage_available_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 20: Check if a view 'viram_utilization' exists
+"Check if a view 'viram_utilization' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viram_utilization'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 20 ' || ('View "viram_utilization" exists in the DB') ELSE 'not ok 20 ' || ('View "viram_utilization" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 21: Ensure 'viram_utilization' view has values 
+"Ensure 'viram_utilization' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viram_utilization_count FROM viram_utilization
+  )
+  SELECT CASE WHEN viram_utilization_count > 0 THEN 'ok 21 ' || ('viram_utilization_count is greater than 0') ELSE 'not ok 21 ' || ('viram_utilization_count should be greater than 0, is ' || viram_utilization_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 22: Check if a view 'vicpu_infomation' exists
+"Check if a view 'vicpu_infomation' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vicpu_infomation'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 22 ' || ('View "vicpu_infomation" exists in the DB') ELSE 'not ok 22 ' || ('View "vicpu_infomation" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 23: Ensure 'vicpu_infomation' view has values 
+"Ensure 'vicpu_infomation' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vicpu_infomation_count FROM vicpu_infomation
+  )
+  SELECT CASE WHEN vicpu_infomation_count > 0 THEN 'ok 23 ' || ('vicpu_infomation_count is greater than 0') ELSE 'not ok 23 ' || ('vicpu_infomation_count should be greater than 0, is ' || vicpu_infomation_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 24: Check if a view 'viaccounts_removed' exists
+"Check if a view 'viaccounts_removed' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viaccounts_removed'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 24 ' || ('View "viaccounts_removed" exists in the DB') ELSE 'not ok 24 ' || ('View "viaccounts_removed" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 25: Ensure 'viaccounts_removed' view has values 
+"Ensure 'viaccounts_removed' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viaccounts_removed_count FROM viaccounts_removed
+  )
+  SELECT CASE WHEN viaccounts_removed_count > 0 THEN 'ok 25 ' || ('viaccounts_removed_count is greater than 0') ELSE 'not ok 25 ' || ('viaccounts_removed_count should be greater than 0, is ' || viaccounts_removed_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 26: Check if a view 'vissh_settings' exists
+"Check if a view 'vissh_settings' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'vissh_settings'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 26 ' || ('View "vissh_settings" exists in the DB') ELSE 'not ok 26 ' || ('View "vissh_settings" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 27: Ensure 'vissh_settings' view has values 
+"Ensure 'vissh_settings' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS vissh_settings_count FROM vissh_settings
+  )
+  SELECT CASE WHEN vissh_settings_count > 0 THEN 'ok 27 ' || ('vissh_settings_count is greater than 0') ELSE 'not ok 27 ' || ('vissh_settings_count should be greater than 0, is ' || vissh_settings_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 28: Check if a view 'viunsuccessful_attempts_log' exists
+"Check if a view 'viunsuccessful_attempts_log' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viunsuccessful_attempts_log'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 28 ' || ('View "viunsuccessful_attempts_log" exists in the DB') ELSE 'not ok 28 ' || ('View "viunsuccessful_attempts_log" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 29: Ensure 'viunsuccessful_attempts_log' view has values 
+"Ensure 'viunsuccessful_attempts_log' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viunsuccessful_attempts_log_count FROM viunsuccessful_attempts_log
+  )
+  SELECT CASE WHEN viunsuccessful_attempts_log_count > 0 THEN 'ok 29 ' || ('viunsuccessful_attempts_log_count is greater than 0') ELSE 'not ok 29 ' || ('viunsuccessful_attempts_log_count should be greater than 0, is ' || viunsuccessful_attempts_log_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 30: Check if a view 'viauthentication' exists
+"Check if a view 'viauthentication' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'viauthentication'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 30 ' || ('View "viauthentication" exists in the DB') ELSE 'not ok 30 ' || ('View "viauthentication" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 31: Ensure 'viauthentication' view has values 
+"Ensure 'viauthentication' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS viauthentication_count FROM viauthentication
+  )
+  SELECT CASE WHEN viauthentication_count > 0 THEN 'ok 31 ' || ('viauthentication_count is greater than 0') ELSE 'not ok 31 ' || ('viauthentication_count should be greater than 0, is ' || viauthentication_count || ' instead') END AS tap_result FROM test_case
+)
+    SELECT tap_result FROM tap_version
+    UNION ALL
+    SELECT tap_result FROM tap_plan
+    UNION ALL
+    SELECT tap_result FROM "Check if a view 'policy_dashboard' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'policy_dashboard' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'policy_detail' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'policy_detail' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'policy_list' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'policy_list' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vigetallviews' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vigetallviews' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viup_time' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viup_time' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viLog' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viLog' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viencrypted_passwords' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viencrypted_passwords' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vinetwork_log' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vinetwork_log' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vissl_certificate' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vissl_certificate' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vistorage_available' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vistorage_available' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viram_utilization' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viram_utilization' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vicpu_infomation' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vicpu_infomation' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viaccounts_removed' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viaccounts_removed' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'vissh_settings' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'vissh_settings' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viunsuccessful_attempts_log' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viunsuccessful_attempts_log' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'viauthentication' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'viauthentication' view has values ";
+SELECT * FROM synthetic_test_suite;

--- a/lib/pattern/info-assurance-policies/tap.sql.ts
+++ b/lib/pattern/info-assurance-policies/tap.sql.ts
@@ -1,0 +1,296 @@
+import { tapNB } from "../../std/notebook/mod.ts";
+type TestCaseContext = tapNB.TestCaseContext;
+export class SyntheticTestSuite extends tapNB.TestSuiteNotebook {
+    // any method that ends in DDL, SQL, DML, or DQL will be "arbitrary SQL"
+    // and included in the SQL stream before all the test cases
+
+    "Check if a view 'policy_dashboard' exists"(ctx: TestCaseContext) {
+        const viewName = "policy_dashboard";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'policy_dashboard' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"policy_dashboard_count">(ctx)`
+            SELECT COUNT(*) AS policy_dashboard_count FROM policy_dashboard`
+            .greaterThan("policy_dashboard_count", 0);
+    }
+
+    "Check if a view 'policy_detail' exists"(ctx: TestCaseContext) {
+        const viewName = "policy_detail";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'policy_detail' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"policy_detail_count">(ctx)`
+            SELECT COUNT(*) AS policy_detail_count FROM policy_detail`
+            .greaterThan("policy_detail_count", 0);
+    }
+
+    "Check if a view 'policy_list' exists"(ctx: TestCaseContext) {
+        const viewName = "policy_list";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'policy_list' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"policy_list_count">(ctx)`
+            SELECT COUNT(*) AS policy_list_count FROM policy_list`
+            .greaterThan("policy_list_count", 0);
+    }
+
+    "Check if a view 'vigetallviews' exists"(ctx: TestCaseContext) {
+        const viewName = "vigetallviews";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vigetallviews' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vigetallviews_count">(ctx)`
+            SELECT COUNT(*) AS vigetallviews_count FROM vigetallviews`
+            .greaterThan("vigetallviews_count", 0);
+    }
+
+    "Check if a view 'viup_time' exists"(ctx: TestCaseContext) {
+        const viewName = "viup_time";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viup_time' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"viup_time_count">(ctx)`
+            SELECT COUNT(*) AS viup_time_count FROM viup_time`
+            .greaterThan("viup_time_count", 0);
+    }
+
+    "Check if a view 'viLog' exists"(ctx: TestCaseContext) {
+        const viewName = "viLog";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viLog' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"viLog_count">(ctx)`
+            SELECT COUNT(*) AS viLog_count FROM viLog`
+            .greaterThan("viLog_count", 0);
+    }
+
+    "Check if a view 'viencrypted_passwords' exists"(ctx: TestCaseContext) {
+        const viewName = "viencrypted_passwords";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viencrypted_passwords' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"viencrypted_passwords_count">(ctx)`
+            SELECT COUNT(*) AS viencrypted_passwords_count FROM viencrypted_passwords`
+            .greaterThan("viencrypted_passwords_count", 0);
+    }
+
+    "Check if a view 'vinetwork_log' exists"(ctx: TestCaseContext) {
+        const viewName = "vinetwork_log";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vinetwork_log' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vinetwork_log_count">(ctx)`
+            SELECT COUNT(*) AS vinetwork_log_count FROM vinetwork_log`
+            .greaterThan("vinetwork_log_count", 0);
+    }
+
+    "Check if a view 'vissl_certificate' exists"(ctx: TestCaseContext) {
+        const viewName = "vissl_certificate";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vissl_certificate' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vissl_certificate_count">(ctx)`
+            SELECT COUNT(*) AS vissl_certificate_count FROM vissl_certificate`
+            .greaterThan("vissl_certificate_count", 0);
+    }
+
+    "Check if a view 'vistorage_available' exists"(ctx: TestCaseContext) {
+        const viewName = "vistorage_available";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vistorage_available' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vistorage_available_count">(ctx)`
+            SELECT COUNT(*) AS vistorage_available_count FROM vistorage_available`
+            .greaterThan("vistorage_available_count", 0);
+    }
+
+    "Check if a view 'viram_utilization' exists"(ctx: TestCaseContext) {
+        const viewName = "viram_utilization";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viram_utilization' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"viram_utilization_count">(ctx)`
+            SELECT COUNT(*) AS viram_utilization_count FROM viram_utilization`
+            .greaterThan("viram_utilization_count", 0);
+    }
+
+    "Check if a view 'vicpu_infomation' exists"(ctx: TestCaseContext) {
+        const viewName = "vicpu_infomation";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vicpu_infomation' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vicpu_infomation_count">(ctx)`
+            SELECT COUNT(*) AS vicpu_infomation_count FROM vicpu_infomation`
+            .greaterThan("vicpu_infomation_count", 0);
+    }
+
+    "Check if a view 'viaccounts_removed' exists"(ctx: TestCaseContext) {
+        const viewName = "viaccounts_removed";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viaccounts_removed' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"viaccounts_removed_count">(ctx)`
+            SELECT COUNT(*) AS viaccounts_removed_count FROM viaccounts_removed`
+            .greaterThan("viaccounts_removed_count", 0);
+    }
+
+    "Check if a view 'vissh_settings' exists"(ctx: TestCaseContext) {
+        const viewName = "vissh_settings";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'vissh_settings' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"vissh_settings_count">(ctx)`
+            SELECT COUNT(*) AS vissh_settings_count FROM vissh_settings`
+            .greaterThan("vissh_settings_count", 0);
+    }
+
+    "Check if a view 'viunsuccessful_attempts_log' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "viunsuccessful_attempts_log";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viunsuccessful_attempts_log' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"viunsuccessful_attempts_log_count">(ctx)`
+            SELECT COUNT(*) AS viunsuccessful_attempts_log_count FROM viunsuccessful_attempts_log`
+            .greaterThan("viunsuccessful_attempts_log_count", 0);
+    }
+
+    "Check if a view 'viauthentication' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "viauthentication";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'viauthentication' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"viauthentication_count">(ctx)`
+            SELECT COUNT(*) AS viauthentication_count FROM viauthentication`
+            .greaterThan("viauthentication_count", 0);
+    }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    const SQL = await tapNB.TestSuiteNotebook.SQL(
+        new SyntheticTestSuite("synthetic_test_suite"),
+    );
+
+    console.log(SQL.join("\n"));
+    console.log(`SELECT * FROM synthetic_test_suite;`);
+}

--- a/lib/pattern/info-assurance/README.md
+++ b/lib/pattern/info-assurance/README.md
@@ -54,3 +54,18 @@ To execute test and ensure that `surveilr` is functioning correctly:
 
 The `-A` flag provides all necessary permissions for the tests to run, including
 file system access and network permissions.
+
+## How to Run the Tap Tests
+
+### RUN THIS TEST this using CLI
+
+`rm -f tap.sql &&  deno run -A ./tap.sql.ts > tap.sql`
+
+This will generate a tap.sql file from tap.sql.ts
+
+`cat tap.sql | sqlite3 resource-surveillance.sqlite.db && sqlite3 resource-surveillance.sqlite.db -cmd "
+SELECT * FROM synthetic_test_suite;"`
+
+This script demonstrates how to create a Test Anything Protocol (TAP) report
+using SQLite, following TAP version 14. It includes multiple test cases, and
+subtests are formatted with indentation per TAP 14's subtest style.

--- a/lib/pattern/info-assurance/tap.sql
+++ b/lib/pattern/info-assurance/tap.sql
@@ -1,0 +1,45 @@
+DROP VIEW IF EXISTS "synthetic_test_suite";
+CREATE VIEW "synthetic_test_suite" AS
+    WITH
+        tap_version AS (SELECT 'TAP version 14' AS tap_result),
+        tap_plan AS (SELECT '1..4' AS tap_result),
+        -- 0: Check if a view 'threat_model' exists
+"Check if a view 'threat_model' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'threat_model'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 0 ' || ('View "threat_model" exists in the DB') ELSE 'not ok 0 ' || ('View "threat_model" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 1: Ensure 'threat_model' view has values 
+"Ensure 'threat_model' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS threat_model_count FROM threat_model
+  )
+  SELECT CASE WHEN threat_model_count > 0 THEN 'ok 1 ' || ('threat_model_count is greater than 0') ELSE 'not ok 1 ' || ('threat_model_count should be greater than 0, is ' || threat_model_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 2: Check if a view 'sql_database' exists
+"Check if a view 'sql_database' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'sql_database'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 2 ' || ('View "sql_database" exists in the DB') ELSE 'not ok 2 ' || ('View "sql_database" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 3: Ensure 'sql_database' view has values 
+"Ensure 'sql_database' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS sql_database_count FROM threat_model
+  )
+  SELECT CASE WHEN sql_database_count > 0 THEN 'ok 3 ' || ('sql_database_count is greater than 0') ELSE 'not ok 3 ' || ('sql_database_count should be greater than 0, is ' || sql_database_count || ' instead') END AS tap_result FROM test_case
+)
+    SELECT tap_result FROM tap_version
+    UNION ALL
+    SELECT tap_result FROM tap_plan
+    UNION ALL
+    SELECT tap_result FROM "Check if a view 'threat_model' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'threat_model' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'sql_database' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'sql_database' view has values ";
+SELECT * FROM synthetic_test_suite;

--- a/lib/pattern/info-assurance/tap.sql.ts
+++ b/lib/pattern/info-assurance/tap.sql.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run --allow-sys
+import { tapNB } from "../../std/notebook/mod.ts";
+type TestCaseContext = tapNB.TestCaseContext;
+export class SyntheticTestSuite extends tapNB.TestSuiteNotebook {
+    // any method that ends in DDL, SQL, DML, or DQL will be "arbitrary SQL"
+    // and included in the SQL stream before all the test cases
+
+    "Check if a view 'threat_model' exists"(ctx: TestCaseContext) {
+        const viewName = "threat_model";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'threat_model' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"threat_model_count">(ctx)`
+            SELECT COUNT(*) AS threat_model_count FROM threat_model`
+            .greaterThan("threat_model_count", 0);
+    }
+
+    "Check if a view 'sql_database' exists"(ctx: TestCaseContext) {
+        const viewName = "sql_database";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'sql_database' view has values "(ctx: TestCaseContext) {
+        return this.assertThat<"sql_database_count">(ctx)`
+            SELECT COUNT(*) AS sql_database_count FROM threat_model`
+            .greaterThan("sql_database_count", 0);
+    }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    const SQL = await tapNB.TestSuiteNotebook.SQL(
+        new SyntheticTestSuite("synthetic_test_suite"),
+    );
+
+    console.log(SQL.join("\n"));
+    console.log(`SELECT * FROM synthetic_test_suite;`);
+}

--- a/lib/pattern/infra-assurance/README.md
+++ b/lib/pattern/infra-assurance/README.md
@@ -56,3 +56,18 @@ To execute test and ensure that `surveilr` is functioning correctly:
 
 The `-A` flag provides all necessary permissions for the tests to run, including
 file system access and network permissions.
+
+## How to Run the Tap Tests
+
+### RUN THIS TEST this using CLI
+
+`rm -f tap.sql &&  deno run -A ./tap.sql.ts > tap.sql`
+
+This will generate a tap.sql file from tap.sql.ts
+
+`cat tap.sql | sqlite3 resource-surveillance.sqlite.db && sqlite3 resource-surveillance.sqlite.db -cmd "
+SELECT * FROM synthetic_test_suite;"`
+
+This script demonstrates how to create a Test Anything Protocol (TAP) report
+using SQLite, following TAP version 14. It includes multiple test cases, and
+subtests are formatted with indentation per TAP 14's subtest style.

--- a/lib/pattern/infra-assurance/tap.sql
+++ b/lib/pattern/infra-assurance/tap.sql
@@ -1,0 +1,107 @@
+DROP VIEW IF EXISTS "synthetic_test_suite";
+CREATE VIEW "synthetic_test_suite" AS
+    WITH
+        tap_version AS (SELECT 'TAP version 14' AS tap_result),
+        tap_plan AS (SELECT '1..10' AS tap_result),
+        -- 0: Check if a view 'border_boundary' exists
+"Check if a view 'border_boundary' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'border_boundary'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 0 ' || ('View "border_boundary" exists in the DB') ELSE 'not ok 0 ' || ('View "border_boundary" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 1: Ensure at least four boundaries
+"Ensure at least four boundaries" AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS boundary_count FROM border_boundary
+  )
+  SELECT CASE WHEN boundary_count = 4 THEN 'ok 1 ' || ('boundary_count is 4') ELSE 'not ok 1 ' || ('boundary_count should be 4, is ' || boundary_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 2: Check if a baundary named 'User Trust Boundary' exists in the View
+"Check if a baundary named 'User Trust Boundary' exists in the View" AS (
+  WITH test_case AS (
+    SELECT name as boundary_name
+  FROM border_boundary
+ WHERE name = 'User Trust Boundary'
+  )
+  SELECT CASE WHEN boundary_name = 'User Trust Boundary' THEN 'ok 2 ' || ('boundary_name is ''User Trust Boundary''') ELSE 'not ok 2 ' || ('boundary_name should be ''User Trust Boundary'', is ' || boundary_name || ' instead') END AS tap_result FROM test_case
+),
+  -- 3: Check if a baundary named 'DigitalOcean Trust Boundary' exists in the View
+"Check if a baundary named 'DigitalOcean Trust Boundary' exists in the View" AS (
+  WITH test_case AS (
+    SELECT name as boundary_name
+  FROM border_boundary
+ WHERE name = 'DigitalOcean Trust Boundary'
+  )
+  SELECT CASE WHEN boundary_name = 'DigitalOcean Trust Boundary' THEN 'ok 3 ' || ('boundary_name is ''DigitalOcean Trust Boundary''') ELSE 'not ok 3 ' || ('boundary_name should be ''DigitalOcean Trust Boundary'', is ' || boundary_name || ' instead') END AS tap_result FROM test_case
+),
+  -- 4: Check if a baundary named 'FCR Trust Boundary' exists in the View
+"Check if a baundary named 'FCR Trust Boundary' exists in the View" AS (
+  WITH test_case AS (
+    SELECT name as boundary_name
+  FROM border_boundary
+ WHERE name = 'FCR Trust Boundary'
+  )
+  SELECT CASE WHEN boundary_name = 'FCR Trust Boundary' THEN 'ok 4 ' || ('boundary_name is ''FCR Trust Boundary''') ELSE 'not ok 4 ' || ('boundary_name should be ''FCR Trust Boundary'', is ' || boundary_name || ' instead') END AS tap_result FROM test_case
+),
+  -- 5: Check if a baundary named 'Hetzner Trust Boundary' exists in the View
+"Check if a baundary named 'Hetzner Trust Boundary' exists in the View" AS (
+  WITH test_case AS (
+    SELECT name as boundary_name
+  FROM border_boundary
+ WHERE name = 'Hetzner Trust Boundary'
+  )
+  SELECT CASE WHEN boundary_name = 'Hetzner Trust Boundary' THEN 'ok 5 ' || ('boundary_name is ''Hetzner Trust Boundary''') ELSE 'not ok 5 ' || ('boundary_name should be ''Hetzner Trust Boundary'', is ' || boundary_name || ' instead') END AS tap_result FROM test_case
+),
+  -- 6: Check if a view 'asset_service_view' exists
+"Check if a view 'asset_service_view' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'asset_service_view'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 6 ' || ('View "asset_service_view" exists in the DB') ELSE 'not ok 6 ' || ('View "asset_service_view" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 7: Check if a view 'server_data' exists
+"Check if a view 'server_data' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'server_data'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 7 ' || ('View "server_data" exists in the DB') ELSE 'not ok 7 ' || ('View "server_data" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 8: Check if a view 'security_incident_response_view' exists
+"Check if a view 'security_incident_response_view' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'security_incident_response_view'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 8 ' || ('View "security_incident_response_view" exists in the DB') ELSE 'not ok 8 ' || ('View "security_incident_response_view" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 9: Check if a view 'security_impact_analysis_view' exists
+"Check if a view 'security_impact_analysis_view' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'security_impact_analysis_view'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 9 ' || ('View "security_impact_analysis_view" exists in the DB') ELSE 'not ok 9 ' || ('View "security_impact_analysis_view" not exists in the DB') END AS tap_result FROM test_case
+)
+    SELECT tap_result FROM tap_version
+    UNION ALL
+    SELECT tap_result FROM tap_plan
+    UNION ALL
+    SELECT tap_result FROM "Check if a view 'border_boundary' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure at least four boundaries"
+    UNION ALL
+SELECT tap_result FROM "Check if a baundary named 'User Trust Boundary' exists in the View"
+    UNION ALL
+SELECT tap_result FROM "Check if a baundary named 'DigitalOcean Trust Boundary' exists in the View"
+    UNION ALL
+SELECT tap_result FROM "Check if a baundary named 'FCR Trust Boundary' exists in the View"
+    UNION ALL
+SELECT tap_result FROM "Check if a baundary named 'Hetzner Trust Boundary' exists in the View"
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'asset_service_view' exists"
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'server_data' exists"
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'security_incident_response_view' exists"
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'security_impact_analysis_view' exists";
+SELECT * FROM synthetic_test_suite;

--- a/lib/pattern/infra-assurance/tap.sql.ts
+++ b/lib/pattern/infra-assurance/tap.sql.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run --allow-sys
+import { tapNB } from "../../std/notebook/mod.ts";
+type TestCaseContext = tapNB.TestCaseContext;
+export class SyntheticTestSuite extends tapNB.TestSuiteNotebook {
+    // any method that ends in DDL, SQL, DML, or DQL will be "arbitrary SQL"
+    // and included in the SQL stream before all the test cases
+
+    "Check if a view 'border_boundary' exists"(ctx: TestCaseContext) {
+        const viewName = "border_boundary";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure at least four boundaries"(ctx: TestCaseContext) {
+        return this.assertThat<"boundary_count">(ctx)`
+            SELECT COUNT(*) AS boundary_count FROM border_boundary`
+            .equals("boundary_count", 4);
+    }
+
+    "Check if a baundary named 'User Trust Boundary' exists in the View"(
+        ctx: TestCaseContext,
+    ) {
+        const checkBoundary = "User Trust Boundary";
+        return this.assertThat<"boundary_name">(ctx)`
+            SELECT name as boundary_name
+              FROM border_boundary
+             WHERE name = '${checkBoundary}'`
+            .equals("boundary_name", `'${checkBoundary}'`);
+    }
+
+    "Check if a baundary named 'DigitalOcean Trust Boundary' exists in the View"(
+        ctx: TestCaseContext,
+    ) {
+        const checkBoundary = "DigitalOcean Trust Boundary";
+        return this.assertThat<"boundary_name">(ctx)`
+            SELECT name as boundary_name
+              FROM border_boundary
+             WHERE name = '${checkBoundary}'`
+            .equals("boundary_name", `'${checkBoundary}'`);
+    }
+
+    "Check if a baundary named 'FCR Trust Boundary' exists in the View"(
+        ctx: TestCaseContext,
+    ) {
+        const checkBoundary = "FCR Trust Boundary";
+        return this.assertThat<"boundary_name">(ctx)`
+            SELECT name as boundary_name
+              FROM border_boundary
+             WHERE name = '${checkBoundary}'`
+            .equals("boundary_name", `'${checkBoundary}'`);
+    }
+
+    "Check if a baundary named 'Hetzner Trust Boundary' exists in the View"(
+        ctx: TestCaseContext,
+    ) {
+        const checkBoundary = "Hetzner Trust Boundary";
+        return this.assertThat<"boundary_name">(ctx)`
+            SELECT name as boundary_name
+              FROM border_boundary
+             WHERE name = '${checkBoundary}'`
+            .equals("boundary_name", `'${checkBoundary}'`);
+    }
+
+    "Check if a view 'asset_service_view' exists"(ctx: TestCaseContext) {
+        const viewName = "asset_service_view";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Check if a view 'server_data' exists"(ctx: TestCaseContext) {
+        const viewName = "server_data";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Check if a view 'security_incident_response_view' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "security_incident_response_view";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Check if a view 'security_impact_analysis_view' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "security_impact_analysis_view";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    const SQL = await tapNB.TestSuiteNotebook.SQL(
+        new SyntheticTestSuite("synthetic_test_suite"),
+    );
+
+    console.log(SQL.join("\n"));
+    console.log(`SELECT * FROM synthetic_test_suite;`);
+}

--- a/lib/pattern/infra-audit/README.md
+++ b/lib/pattern/infra-audit/README.md
@@ -37,3 +37,18 @@ $ ../../std/surveilrctl.ts dev
 # browse http://localhost:9000/ to see surveilr web UI
 # browse http://localhost:9000/infra-audit/info-schema.sql to see infra-audit views and tables
 ```
+
+## How to Run the Tap Tests
+
+### RUN THIS TEST this using CLI
+
+`rm -f tap.sql &&  deno run -A ./tap.sql.ts > tap.sql`
+
+This will generate a tap.sql file from tap.sql.ts
+
+`cat tap.sql | sqlite3 resource-surveillance.sqlite.db && sqlite3 resource-surveillance.sqlite.db -cmd "
+SELECT * FROM synthetic_test_suite;"`
+
+This script demonstrates how to create a Test Anything Protocol (TAP) report
+using SQLite, following TAP version 14. It includes multiple test cases, and
+subtests are formatted with indentation per TAP 14's subtest style.

--- a/lib/pattern/infra-audit/tap.sql
+++ b/lib/pattern/infra-audit/tap.sql
@@ -1,0 +1,315 @@
+DROP VIEW IF EXISTS "synthetic_test_suite";
+CREATE VIEW "synthetic_test_suite" AS
+    WITH
+        tap_version AS (SELECT 'TAP version 14' AS tap_result),
+        tap_plan AS (SELECT '1..34' AS tap_result),
+        -- 0: Check if a view 'tenant_based_control_regime' exists
+"Check if a view 'tenant_based_control_regime' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'tenant_based_control_regime'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 0 ' || ('View "tenant_based_control_regime" exists in the DB') ELSE 'not ok 0 ' || ('View "tenant_based_control_regime" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 1: Ensure 'tenant_based_control_regime' view has values 
+"Ensure 'tenant_based_control_regime' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS tenant_based_control_regime_count FROM tenant_based_control_regime
+  )
+  SELECT CASE WHEN tenant_based_control_regime_count > 0 THEN 'ok 1 ' || ('tenant_based_control_regime_count is greater than 0') ELSE 'not ok 1 ' || ('tenant_based_control_regime_count should be greater than 0, is ' || tenant_based_control_regime_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 2: Check if a view 'audit_session_control' exists
+"Check if a view 'audit_session_control' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_session_control'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 2 ' || ('View "audit_session_control" exists in the DB') ELSE 'not ok 2 ' || ('View "audit_session_control" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 3: Ensure 'audit_session_control' view has values 
+"Ensure 'audit_session_control' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_session_control_count FROM audit_session_control
+  )
+  SELECT CASE WHEN audit_session_control_count > 0 THEN 'ok 3 ' || ('audit_session_control_count is greater than 0') ELSE 'not ok 3 ' || ('audit_session_control_count should be greater than 0, is ' || audit_session_control_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 4: Check if a view 'audit_session_list' exists
+"Check if a view 'audit_session_list' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_session_list'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 4 ' || ('View "audit_session_list" exists in the DB') ELSE 'not ok 4 ' || ('View "audit_session_list" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 5: Ensure 'audit_session_list' view has values 
+"Ensure 'audit_session_list' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_session_list_count FROM audit_session_list
+  )
+  SELECT CASE WHEN audit_session_list_count > 0 THEN 'ok 5 ' || ('audit_session_list_count is greater than 0') ELSE 'not ok 5 ' || ('audit_session_list_count should be greater than 0, is ' || audit_session_list_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 6: Check if a view 'query_result' exists
+"Check if a view 'query_result' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'query_result'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 6 ' || ('View "query_result" exists in the DB') ELSE 'not ok 6 ' || ('View "query_result" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 7: Ensure 'query_result' view has values 
+"Ensure 'query_result' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS query_result_count FROM query_result
+  )
+  SELECT CASE WHEN query_result_count > 0 THEN 'ok 7 ' || ('query_result_count is greater than 0') ELSE 'not ok 7 ' || ('query_result_count should be greater than 0, is ' || query_result_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 8: Check if a view 'audit_session_info' exists
+"Check if a view 'audit_session_info' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_session_info'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 8 ' || ('View "audit_session_info" exists in the DB') ELSE 'not ok 8 ' || ('View "audit_session_info" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 9: Ensure 'audit_session_info' view has values 
+"Ensure 'audit_session_info' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_session_info_count FROM audit_session_info
+  )
+  SELECT CASE WHEN audit_session_info_count > 0 THEN 'ok 9 ' || ('audit_session_info_count is greater than 0') ELSE 'not ok 9 ' || ('audit_session_info_count should be greater than 0, is ' || audit_session_info_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 10: Check if a view 'evidence_query_result' exists
+"Check if a view 'evidence_query_result' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence_query_result'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 10 ' || ('View "evidence_query_result" exists in the DB') ELSE 'not ok 10 ' || ('View "evidence_query_result" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 11: Ensure 'evidence_query_result' view has values 
+"Ensure 'evidence_query_result' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_query_result_count FROM evidence_query_result
+  )
+  SELECT CASE WHEN evidence_query_result_count > 0 THEN 'ok 11 ' || ('evidence_query_result_count is greater than 0') ELSE 'not ok 11 ' || ('evidence_query_result_count should be greater than 0, is ' || evidence_query_result_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 12: Check if a view 'audit_session_control_group' exists
+"Check if a view 'audit_session_control_group' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_session_control_group'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 12 ' || ('View "audit_session_control_group" exists in the DB') ELSE 'not ok 12 ' || ('View "audit_session_control_group" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 13: Ensure 'audit_session_control_group' view has values 
+"Ensure 'audit_session_control_group' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_session_control_group_count FROM audit_session_control_group
+  )
+  SELECT CASE WHEN audit_session_control_group_count > 0 THEN 'ok 13 ' || ('audit_session_control_group_count is greater than 0') ELSE 'not ok 13 ' || ('audit_session_control_group_count should be greater than 0, is ' || audit_session_control_group_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 14: Check if a view 'audit_control_evidence' exists
+"Check if a view 'audit_control_evidence' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_control_evidence'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 14 ' || ('View "audit_control_evidence" exists in the DB') ELSE 'not ok 14 ' || ('View "audit_control_evidence" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 15: Ensure 'audit_control_evidence' view has values 
+"Ensure 'audit_control_evidence' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_control_evidence_count FROM audit_control_evidence
+  )
+  SELECT CASE WHEN audit_control_evidence_count > 0 THEN 'ok 15 ' || ('audit_control_evidence_count is greater than 0') ELSE 'not ok 15 ' || ('audit_control_evidence_count should be greater than 0, is ' || audit_control_evidence_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 16: Check if a view 'policy' exists
+"Check if a view 'policy' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'policy'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 16 ' || ('View "policy" exists in the DB') ELSE 'not ok 16 ' || ('View "policy" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 17: Ensure 'policy' view has values 
+"Ensure 'policy' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS policy_count FROM policy
+  )
+  SELECT CASE WHEN policy_count > 0 THEN 'ok 17 ' || ('policy_count is greater than 0') ELSE 'not ok 17 ' || ('policy_count should be greater than 0, is ' || policy_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 18: Check if a view 'evidence' exists
+"Check if a view 'evidence' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 18 ' || ('View "evidence" exists in the DB') ELSE 'not ok 18 ' || ('View "evidence" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 19: Ensure 'evidence' view has values 
+"Ensure 'evidence' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_count FROM evidence
+  )
+  SELECT CASE WHEN evidence_count > 0 THEN 'ok 19 ' || ('evidence_count is greater than 0') ELSE 'not ok 19 ' || ('evidence_count should be greater than 0, is ' || evidence_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 20: Check if a view 'evidence_evidenceresult' exists
+"Check if a view 'evidence_evidenceresult' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence_evidenceresult'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 20 ' || ('View "evidence_evidenceresult" exists in the DB') ELSE 'not ok 20 ' || ('View "evidence_evidenceresult" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 21: Ensure 'evidence_evidenceresult' view has values 
+"Ensure 'evidence_evidenceresult' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_evidenceresult_count FROM evidence_evidenceresult
+  )
+  SELECT CASE WHEN evidence_evidenceresult_count > 0 THEN 'ok 21 ' || ('evidence_evidenceresult_count is greater than 0') ELSE 'not ok 21 ' || ('evidence_evidenceresult_count should be greater than 0, is ' || evidence_evidenceresult_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 22: Check if a view 'evidence_customtag' exists
+"Check if a view 'evidence_customtag' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence_customtag'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 22 ' || ('View "evidence_customtag" exists in the DB') ELSE 'not ok 22 ' || ('View "evidence_customtag" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 23: Ensure 'evidence_customtag' view has values 
+"Ensure 'evidence_customtag' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_customtag_count FROM evidence_customtag
+  )
+  SELECT CASE WHEN evidence_customtag_count > 0 THEN 'ok 23 ' || ('evidence_customtag_count is greater than 0') ELSE 'not ok 23 ' || ('evidence_customtag_count should be greater than 0, is ' || evidence_customtag_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 24: Check if a view 'evidence_anchortag' exists
+"Check if a view 'evidence_anchortag' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence_anchortag'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 24 ' || ('View "evidence_anchortag" exists in the DB') ELSE 'not ok 24 ' || ('View "evidence_anchortag" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 25: Ensure 'evidence_anchortag' view has values 
+"Ensure 'evidence_anchortag' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_anchortag_count FROM evidence_anchortag
+  )
+  SELECT CASE WHEN evidence_anchortag_count > 0 THEN 'ok 25 ' || ('evidence_anchortag_count is greater than 0') ELSE 'not ok 25 ' || ('evidence_anchortag_count should be greater than 0, is ' || evidence_anchortag_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 26: Check if a view 'evidence_imagetag' exists
+"Check if a view 'evidence_imagetag' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'evidence_imagetag'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 26 ' || ('View "evidence_imagetag" exists in the DB') ELSE 'not ok 26 ' || ('View "evidence_imagetag" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 27: Ensure 'evidence_imagetag' view has values 
+"Ensure 'evidence_imagetag' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS evidence_imagetag_count FROM evidence_imagetag
+  )
+  SELECT CASE WHEN evidence_imagetag_count > 0 THEN 'ok 27 ' || ('evidence_imagetag_count is greater than 0') ELSE 'not ok 27 ' || ('evidence_imagetag_count should be greater than 0, is ' || evidence_imagetag_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 28: Check if a view 'audit_session_control_status' exists
+"Check if a view 'audit_session_control_status' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'audit_session_control_status'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 28 ' || ('View "audit_session_control_status" exists in the DB') ELSE 'not ok 28 ' || ('View "audit_session_control_status" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 29: Ensure 'audit_session_control_status' view has values 
+"Ensure 'audit_session_control_status' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS audit_session_control_status_count FROM audit_session_control_status
+  )
+  SELECT CASE WHEN audit_session_control_status_count > 0 THEN 'ok 29 ' || ('audit_session_control_status_count is greater than 0') ELSE 'not ok 29 ' || ('audit_session_control_status_count should be greater than 0, is ' || audit_session_control_status_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 30: Check if a view 'control_group' exists
+"Check if a view 'control_group' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'control_group'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 30 ' || ('View "control_group" exists in the DB') ELSE 'not ok 30 ' || ('View "control_group" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 31: Ensure 'control_group' view has values 
+"Ensure 'control_group' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS control_group_count FROM control_group
+  )
+  SELECT CASE WHEN control_group_count > 0 THEN 'ok 31 ' || ('control_group_count is greater than 0') ELSE 'not ok 31 ' || ('control_group_count should be greater than 0, is ' || control_group_count || ' instead') END AS tap_result FROM test_case
+),
+  -- 32: Check if a view 'control' exists
+"Check if a view 'control' exists" AS (
+  WITH test_case AS (
+    SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = 'control'
+  )
+  SELECT CASE WHEN exist = 1 THEN 'ok 32 ' || ('View "control" exists in the DB') ELSE 'not ok 32 ' || ('View "control" not exists in the DB') END AS tap_result FROM test_case
+),
+  -- 33: Ensure 'control' view has values 
+"Ensure 'control' view has values " AS (
+  WITH test_case AS (
+    SELECT COUNT(*) AS control_count FROM control
+  )
+  SELECT CASE WHEN control_count > 0 THEN 'ok 33 ' || ('control_count is greater than 0') ELSE 'not ok 33 ' || ('control_count should be greater than 0, is ' || control_count || ' instead') END AS tap_result FROM test_case
+)
+    SELECT tap_result FROM tap_version
+    UNION ALL
+    SELECT tap_result FROM tap_plan
+    UNION ALL
+    SELECT tap_result FROM "Check if a view 'tenant_based_control_regime' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'tenant_based_control_regime' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_session_control' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_session_control' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_session_list' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_session_list' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'query_result' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'query_result' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_session_info' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_session_info' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence_query_result' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence_query_result' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_session_control_group' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_session_control_group' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_control_evidence' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_control_evidence' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'policy' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'policy' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence_evidenceresult' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence_evidenceresult' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence_customtag' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence_customtag' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence_anchortag' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence_anchortag' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'evidence_imagetag' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'evidence_imagetag' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'audit_session_control_status' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'audit_session_control_status' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'control_group' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'control_group' view has values "
+    UNION ALL
+SELECT tap_result FROM "Check if a view 'control' exists"
+    UNION ALL
+SELECT tap_result FROM "Ensure 'control' view has values ";
+SELECT * FROM synthetic_test_suite;

--- a/lib/pattern/infra-audit/tap.sql.ts
+++ b/lib/pattern/infra-audit/tap.sql.ts
@@ -1,0 +1,373 @@
+import { tapNB } from "../../std/notebook/mod.ts";
+type TestCaseContext = tapNB.TestCaseContext;
+export class SyntheticTestSuite extends tapNB.TestSuiteNotebook {
+    // any method that ends in DDL, SQL, DML, or DQL will be "arbitrary SQL"
+    // and included in the SQL stream before all the test cases
+
+    "Check if a view 'tenant_based_control_regime' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "tenant_based_control_regime";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'tenant_based_control_regime' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"tenant_based_control_regime_count">(ctx)`
+            SELECT COUNT(*) AS tenant_based_control_regime_count FROM tenant_based_control_regime`
+            .greaterThan("tenant_based_control_regime_count", 0);
+    }
+
+    "Check if a view 'audit_session_control' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_session_control";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_session_control' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_session_control_count">(ctx)`
+            SELECT COUNT(*) AS audit_session_control_count FROM audit_session_control`
+            .greaterThan("audit_session_control_count", 0);
+    }
+
+    "Check if a view 'audit_session_list' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_session_list";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_session_list' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_session_list_count">(ctx)`
+            SELECT COUNT(*) AS audit_session_list_count FROM audit_session_list`
+            .greaterThan("audit_session_list_count", 0);
+    }
+
+    "Check if a view 'query_result' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "query_result";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'query_result' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"query_result_count">(ctx)`
+            SELECT COUNT(*) AS query_result_count FROM query_result`
+            .greaterThan("query_result_count", 0);
+    }
+
+    "Check if a view 'audit_session_info' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_session_info";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_session_info' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_session_info_count">(ctx)`
+            SELECT COUNT(*) AS audit_session_info_count FROM audit_session_info`
+            .greaterThan("audit_session_info_count", 0);
+    }
+
+    "Check if a view 'evidence_query_result' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence_query_result";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence_query_result' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_query_result_count">(ctx)`
+            SELECT COUNT(*) AS evidence_query_result_count FROM evidence_query_result`
+            .greaterThan("evidence_query_result_count", 0);
+    }
+
+    "Check if a view 'audit_session_control_group' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_session_control_group";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_session_control_group' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_session_control_group_count">(ctx)`
+            SELECT COUNT(*) AS audit_session_control_group_count FROM audit_session_control_group`
+            .greaterThan("audit_session_control_group_count", 0);
+    }
+
+    "Check if a view 'audit_control_evidence' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_control_evidence";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_control_evidence' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_control_evidence_count">(ctx)`
+            SELECT COUNT(*) AS audit_control_evidence_count FROM audit_control_evidence`
+            .greaterThan("audit_control_evidence_count", 0);
+    }
+
+    "Check if a view 'policy' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "policy";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'policy' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"policy_count">(ctx)`
+            SELECT COUNT(*) AS policy_count FROM policy`
+            .greaterThan("policy_count", 0);
+    }
+
+    "Check if a view 'evidence' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_count">(ctx)`
+            SELECT COUNT(*) AS evidence_count FROM evidence`
+            .greaterThan("evidence_count", 0);
+    }
+
+    "Check if a view 'evidence_evidenceresult' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence_evidenceresult";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence_evidenceresult' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_evidenceresult_count">(ctx)`
+            SELECT COUNT(*) AS evidence_evidenceresult_count FROM evidence_evidenceresult`
+            .greaterThan("evidence_evidenceresult_count", 0);
+    }
+
+    "Check if a view 'evidence_customtag' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence_customtag";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence_customtag' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_customtag_count">(ctx)`
+            SELECT COUNT(*) AS evidence_customtag_count FROM evidence_customtag`
+            .greaterThan("evidence_customtag_count", 0);
+    }
+
+    "Check if a view 'evidence_anchortag' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence_anchortag";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence_anchortag' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_anchortag_count">(ctx)`
+            SELECT COUNT(*) AS evidence_anchortag_count FROM evidence_anchortag`
+            .greaterThan("evidence_anchortag_count", 0);
+    }
+
+    "Check if a view 'evidence_imagetag' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "evidence_imagetag";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'evidence_imagetag' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"evidence_imagetag_count">(ctx)`
+            SELECT COUNT(*) AS evidence_imagetag_count FROM evidence_imagetag`
+            .greaterThan("evidence_imagetag_count", 0);
+    }
+
+    "Check if a view 'audit_session_control_status' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "audit_session_control_status";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'audit_session_control_status' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"audit_session_control_status_count">(ctx)`
+            SELECT COUNT(*) AS audit_session_control_status_count FROM audit_session_control_status`
+            .greaterThan("audit_session_control_status_count", 0);
+    }
+
+    "Check if a view 'control_group' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "control_group";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'control_group' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"control_group_count">(ctx)`
+            SELECT COUNT(*) AS control_group_count FROM control_group`
+            .greaterThan("control_group_count", 0);
+    }
+
+    "Check if a view 'control' exists"(
+        ctx: TestCaseContext,
+    ) {
+        const viewName = "control";
+        return this.assertThat(ctx)`
+            SELECT count(name) as exist FROM sqlite_master WHERE type = 'view' AND name = '${viewName}'`
+            .case(
+                `exist = 1`,
+                `View "${viewName}" exists in the DB`,
+                `View "${viewName}" not exists in the DB`,
+            );
+    }
+
+    "Ensure 'control' view has values "(
+        ctx: TestCaseContext,
+    ) {
+        return this.assertThat<"control_count">(ctx)`
+            SELECT COUNT(*) AS control_count FROM control`
+            .greaterThan("control_count", 0);
+    }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    const SQL = await tapNB.TestSuiteNotebook.SQL(
+        new SyntheticTestSuite("synthetic_test_suite"),
+    );
+
+    console.log(SQL.join("\n"));
+    console.log(`SELECT * FROM synthetic_test_suite;`);
+}


### PR DESCRIPTION
This pull request introduces the TAP (Test Anything Protocol) test integration into various assurance patterns to improve automated testing coverage and ensure the reliability of the infra and info assurance-related functionalities.

Added TAP tests for the following patterns:

- info-assurance
- info-assurance-controls
- info-assurance-policies
- infra-assurance
- infra-audit