### PR TITLE
fix: pagination count add where condition #20

### DIFF
--- a/lib/std/notebook/sqlpage.ts
+++ b/lib/std/notebook/sqlpage.ts
@@ -367,7 +367,7 @@ export class TypicalSqlPageNotebook
     config:
       & {
         varName?: (name: string) => string;
-        whereSQL?: string[];
+        whereSQL?: string;
       }
       & ({ readonly tableOrViewName: string; readonly countSQL?: never } | {
         readonly tableOrViewName?: never;
@@ -381,14 +381,8 @@ export class TypicalSqlPageNotebook
       init: () => {
         const countSQL = config.countSQL
           ? config.countSQL
-          : this.SQL`SELECT COUNT(*) FROM ${config.tableOrViewName}${
-            config.whereSQL && config.whereSQL.length > 0
-              ? ` WHERE ${
-                config.whereSQL.map((qp) => `${n(qp)} =${$(qp)}`).join(
-                  " AND ",
-                )
-              }`
-              : ``
+          : this.SQL`SELECT COUNT(*) FROM ${config.tableOrViewName} ${
+            config.whereSQL && config.whereSQL.length > 0 ? config.whereSQL : ``
           }`;
 
         return this.SQL`


### PR DESCRIPTION
This pull request updates the `where` parameter type in the SQL pagination function. Previously, `whereSQL` was expected as an array, but this update changes it to a string, allowing for more flexible and dynamic query composition.

**Code Change**: The `countSQL` query has been adjusted to handle `whereSQL` as a string:
```

const countSQL = config.countSQL
  ? config.countSQL
  : this.SQL`SELECT COUNT(*) FROM ${config.tableOrViewName} ${
      config.whereSQL && config.whereSQL.length > 0 ? config.whereSQL : ``
    }`;
```