### PR TITLE
Add Site Quality Pattern for Social Media and Document Metadata

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -18,7 +18,6 @@
     "npm:@preline/dropdown@^2.5.0": "2.5.0",
     "npm:@preline/overlay@^2.5.0": "2.5.0",
     "npm:@preline/tabs@^2.5.0": "2.5.0",
-    "npm:@tailwindcss/forms@~0.5.9": "0.5.9_tailwindcss@3.4.14__postcss@8.4.47",
     "npm:@types/node@*": "18.16.19",
     "npm:@types/papaparse@*": "5.3.15",
     "npm:astro-compressor@~0.4.1": "0.4.1",
@@ -35,7 +34,6 @@
     "npm:rimraf@^6.0.1": "6.0.1",
     "npm:sharp-ico@~0.1.5": "0.1.5",
     "npm:sharp@~0.33.5": "0.33.5",
-    "npm:tailwindcss@^3.4.14": "3.4.14_postcss@8.4.47",
     "npm:typescript@^5.6.3": "5.6.3"
   },
   "jsr": {
@@ -90,14 +88,11 @@
     }
   },
   "npm": {
-    "@alloc/quick-lru@5.2.0": {
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
-    },
     "@astrojs/check@0.9.4_typescript@5.6.3_prettier@3.3.3_prettier-plugin-astro@0.14.1": {
       "integrity": "sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==",
       "dependencies": [
         "@astrojs/language-server",
-        "chokidar@4.0.1",
+        "chokidar",
         "kleur",
         "typescript",
         "yargs"
@@ -334,9 +329,6 @@
         "fastq"
       ]
     },
-    "@pkgjs/parseargs@0.11.0": {
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="
-    },
     "@preline/accordion@2.5.0": {
       "integrity": "sha512-vQnRTJ0W1FNHsgwgQ/i6OXXDkRuT1oaR9WNjgTX8jeldQfnU40NYCJdjyhdPX5kCkNH2Q8AW6ihG/8XI2DNGJA=="
     },
@@ -354,13 +346,6 @@
     },
     "@sindresorhus/merge-streams@2.3.0": {
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
-    },
-    "@tailwindcss/forms@0.5.9_tailwindcss@3.4.14__postcss@8.4.47": {
-      "integrity": "sha512-tM4XVr2+UVTxXJzey9Twx48c1gcxFStqn1pQz0tRsX8o3DvxhN5oY5pvyAbUx7VTaZxpej4Zzvc6h+1RJBzpIg==",
-      "dependencies": [
-        "mini-svg-data-uri",
-        "tailwindcss"
-      ]
     },
     "@types/node@17.0.45": {
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
@@ -477,16 +462,6 @@
     "ansi-styles@6.2.1": {
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
     },
-    "any-promise@1.3.0": {
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
-    },
-    "anymatch@3.1.3": {
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dependencies": [
-        "normalize-path",
-        "picomatch"
-      ]
-    },
     "arg@5.0.2": {
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
@@ -498,9 +473,6 @@
     },
     "base64-js@1.5.1": {
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "binary-extensions@2.3.0": {
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="
     },
     "brace-expansion@2.0.1": {
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
@@ -534,26 +506,10 @@
         "tslib"
       ]
     },
-    "camelcase-css@2.0.1": {
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
-    },
-    "chokidar@3.6.0": {
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dependencies": [
-        "anymatch",
-        "braces",
-        "fsevents",
-        "glob-parent@5.1.2",
-        "is-binary-path",
-        "is-glob",
-        "normalize-path",
-        "readdirp@3.6.0"
-      ]
-    },
     "chokidar@4.0.1": {
       "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
       "dependencies": [
-        "readdirp@4.0.2"
+        "readdirp"
       ]
     },
     "clean-css@5.3.3": {
@@ -610,9 +566,6 @@
     "commander@2.20.3": {
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "commander@4.1.1": {
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-    },
     "cross-fetch@4.0.0": {
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": [
@@ -626,9 +579,6 @@
         "shebang-command",
         "which"
       ]
-    },
-    "cssesc@3.0.0": {
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "decode-bmp@0.2.1": {
       "integrity": "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA==",
@@ -650,12 +600,6 @@
     },
     "detect-libc@2.0.3": {
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
-    },
-    "didyoumean@1.2.2": {
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
-    },
-    "dlv@1.1.3": {
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "dot-case@3.0.4": {
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
@@ -700,7 +644,7 @@
       "dependencies": [
         "@nodelib/fs.stat",
         "@nodelib/fs.walk",
-        "glob-parent@5.1.2",
+        "glob-parent",
         "merge2",
         "micromatch"
       ]
@@ -733,12 +677,6 @@
         "signal-exit"
       ]
     },
-    "fsevents@2.3.3": {
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
-    },
-    "function-bind@1.1.2": {
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
     "get-caller-file@2.0.5": {
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
@@ -748,32 +686,15 @@
         "is-glob"
       ]
     },
-    "glob-parent@6.0.2": {
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dependencies": [
-        "is-glob"
-      ]
-    },
-    "glob@10.4.5": {
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dependencies": [
-        "foreground-child",
-        "jackspeak@3.4.3",
-        "minimatch@9.0.5",
-        "minipass",
-        "package-json-from-dist",
-        "path-scurry@1.11.1"
-      ]
-    },
     "glob@11.0.0": {
       "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
       "dependencies": [
         "foreground-child",
-        "jackspeak@4.0.2",
-        "minimatch@10.0.1",
+        "jackspeak",
+        "minimatch",
         "minipass",
         "package-json-from-dist",
-        "path-scurry@2.0.0"
+        "path-scurry"
       ]
     },
     "globby@14.0.2": {
@@ -795,12 +716,6 @@
     },
     "gsap@3.12.5": {
       "integrity": "sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ=="
-    },
-    "hasown@2.0.2": {
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dependencies": [
-        "function-bind"
-      ]
     },
     "html-minifier-terser@7.2.0": {
       "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
@@ -826,18 +741,6 @@
     "is-arrayish@0.3.2": {
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
-    "is-binary-path@2.1.0": {
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dependencies": [
-        "binary-extensions"
-      ]
-    },
-    "is-core-module@2.15.1": {
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dependencies": [
-        "hasown"
-      ]
-    },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
@@ -859,21 +762,11 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
-    "jackspeak@3.4.3": {
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dependencies": [
-        "@isaacs/cliui",
-        "@pkgjs/parseargs"
-      ]
-    },
     "jackspeak@4.0.2": {
       "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
       "dependencies": [
         "@isaacs/cliui"
       ]
-    },
-    "jiti@1.21.6": {
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w=="
     },
     "js-base64@3.7.7": {
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
@@ -890,15 +783,6 @@
     "kleur@4.1.5": {
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
-    "lilconfig@2.1.0": {
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
-    },
-    "lilconfig@3.1.2": {
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow=="
-    },
-    "lines-and-columns@1.2.4": {
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
@@ -907,9 +791,6 @@
       "dependencies": [
         "tslib"
       ]
-    },
-    "lru-cache@10.4.3": {
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "lru-cache@11.0.1": {
       "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
@@ -924,17 +805,8 @@
         "picomatch"
       ]
     },
-    "mini-svg-data-uri@1.4.4": {
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="
-    },
     "minimatch@10.0.1": {
       "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "dependencies": [
-        "brace-expansion"
-      ]
-    },
-    "minimatch@9.0.5": {
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": [
         "brace-expansion"
       ]
@@ -944,17 +816,6 @@
     },
     "muggle-string@0.4.1": {
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
-    },
-    "mz@2.7.0": {
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dependencies": [
-        "any-promise",
-        "object-assign",
-        "thenify-all"
-      ]
-    },
-    "nanoid@3.3.7": {
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "no-case@3.0.4": {
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
@@ -968,15 +829,6 @@
       "dependencies": [
         "whatwg-url"
       ]
-    },
-    "normalize-path@3.0.0": {
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "object-assign@4.1.1": {
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
-    },
-    "object-hash@3.0.0": {
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "package-json-from-dist@1.0.1": {
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
@@ -1010,89 +862,21 @@
     "path-key@3.1.1": {
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
-    "path-parse@1.0.7": {
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "path-scurry@1.11.1": {
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dependencies": [
-        "lru-cache@10.4.3",
-        "minipass"
-      ]
-    },
     "path-scurry@2.0.0": {
       "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
       "dependencies": [
-        "lru-cache@11.0.1",
+        "lru-cache",
         "minipass"
       ]
     },
     "path-type@5.0.0": {
       "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg=="
     },
-    "picocolors@1.1.1": {
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
-    },
     "picomatch@2.3.1": {
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
-    "pify@2.3.0": {
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
-    },
-    "pirates@4.0.6": {
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="
-    },
     "pluralize@8.0.0": {
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
-    },
-    "postcss-import@15.1.0_postcss@8.4.47": {
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dependencies": [
-        "postcss",
-        "postcss-value-parser",
-        "read-cache",
-        "resolve"
-      ]
-    },
-    "postcss-js@4.0.1_postcss@8.4.47": {
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dependencies": [
-        "camelcase-css",
-        "postcss"
-      ]
-    },
-    "postcss-load-config@4.0.2_postcss@8.4.47": {
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dependencies": [
-        "lilconfig@3.1.2",
-        "postcss",
-        "yaml@2.5.1"
-      ]
-    },
-    "postcss-nested@6.2.0_postcss@8.4.47": {
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dependencies": [
-        "postcss",
-        "postcss-selector-parser"
-      ]
-    },
-    "postcss-selector-parser@6.1.2": {
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dependencies": [
-        "cssesc",
-        "util-deprecate"
-      ]
-    },
-    "postcss-value-parser@4.2.0": {
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
-    "postcss@8.4.47": {
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
-      "dependencies": [
-        "nanoid",
-        "picocolors",
-        "source-map-js"
-      ]
     },
     "prettier-plugin-astro@0.14.1": {
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
@@ -1140,12 +924,6 @@
         "yaml@2.5.1"
       ]
     },
-    "read-cache@1.0.0": {
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dependencies": [
-        "pify"
-      ]
-    },
     "readable-stream@4.5.2": {
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dependencies": [
@@ -1154,12 +932,6 @@
         "events",
         "process",
         "string_decoder"
-      ]
-    },
-    "readdirp@3.6.0": {
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dependencies": [
-        "picomatch"
       ]
     },
     "readdirp@4.0.2": {
@@ -1180,21 +952,13 @@
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
-    "resolve@1.22.8": {
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dependencies": [
-        "is-core-module",
-        "path-parse",
-        "supports-preserve-symlinks-flag"
-      ]
-    },
     "reusify@1.0.4": {
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf@6.0.1": {
       "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dependencies": [
-        "glob@11.0.0",
+        "glob",
         "package-json-from-dist"
       ]
     },
@@ -1290,9 +1054,6 @@
     "slash@5.1.0": {
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
     },
-    "source-map-js@1.2.1": {
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
-    },
     "source-map-support@0.5.21": {
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dependencies": [
@@ -1343,52 +1104,10 @@
     "strnum@1.0.5": {
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
-    "sucrase@3.35.0": {
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dependencies": [
-        "@jridgewell/gen-mapping",
-        "commander@4.1.1",
-        "glob@10.4.5",
-        "lines-and-columns",
-        "mz",
-        "pirates",
-        "ts-interface-checker"
-      ]
-    },
     "suf-log@2.5.3": {
       "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
       "dependencies": [
         "s.color"
-      ]
-    },
-    "supports-preserve-symlinks-flag@1.0.0": {
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-    },
-    "tailwindcss@3.4.14_postcss@8.4.47": {
-      "integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
-      "dependencies": [
-        "@alloc/quick-lru",
-        "arg",
-        "chokidar@3.6.0",
-        "didyoumean",
-        "dlv",
-        "fast-glob",
-        "glob-parent@6.0.2",
-        "is-glob",
-        "jiti",
-        "lilconfig@2.1.0",
-        "micromatch",
-        "normalize-path",
-        "object-hash",
-        "picocolors",
-        "postcss",
-        "postcss-import",
-        "postcss-js",
-        "postcss-load-config",
-        "postcss-nested",
-        "postcss-selector-parser",
-        "resolve",
-        "sucrase"
       ]
     },
     "terser@5.36.0": {
@@ -1398,18 +1117,6 @@
         "acorn",
         "commander@2.20.3",
         "source-map-support"
-      ]
-    },
-    "thenify-all@1.6.0": {
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dependencies": [
-        "thenify"
-      ]
-    },
-    "thenify@3.3.1": {
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dependencies": [
-        "any-promise"
       ]
     },
     "tiny-emitter@2.1.0": {
@@ -1429,9 +1136,6 @@
     },
     "tr46@0.0.3": {
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "ts-interface-checker@0.1.13": {
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "tslib@2.8.0": {
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
@@ -1467,9 +1171,6 @@
     },
     "urijs@1.19.11": {
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
-    },
-    "util-deprecate@1.0.2": {
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "volar-service-css@0.0.61_@volar+language-service@2.4.6": {
       "integrity": "sha512-Ct9L/w+IB1JU8F4jofcNCGoHy6TF83aiapfZq9A0qYYpq+Kk5dH+ONS+rVZSsuhsunq8UvAuF8Gk6B8IFLfniw==",
@@ -2418,8 +2119,8 @@
         "npm:@vercel/nft@~0.27.6",
         "npm:astro-breadcrumbs@^3.2.0",
         "npm:astro-compressor@~0.4.1",
-        "npm:astro-vtbot@^1.10.6",
-        "npm:astro@^4.16.10",
+        "npm:astro-vtbot@^1.10.7",
+        "npm:astro@^4.16.13",
         "npm:clipboard@^2.0.11",
         "npm:globby@^14.0.2",
         "npm:gsap@^3.12.5",
@@ -2436,10 +2137,10 @@
         "npm:react-dom@^18.3.1",
         "npm:react@^18.3.1",
         "npm:rimraf@^6.0.1",
-        "npm:sass@^1.80.6",
+        "npm:sass@^1.81.0",
         "npm:sharp-ico@~0.1.5",
         "npm:sharp@~0.33.5",
-        "npm:tailwindcss@^3.4.14",
+        "npm:tailwindcss@^3.4.15",
         "npm:typescript@^5.6.3"
       ]
     }

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/control.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/control.md
@@ -1,0 +1,11 @@
+---
+site-quality-control-id: 1
+name: HTML Meta Tags
+fii: FII-SQE-SEO-HMT-0001
+---
+
+HTML meta tags are snippets of text placed in the <head> section of an HTML
+document to provide metadata about the web page. They help browsers, search
+engines, and social media platforms understand the pages content and purpose.
+These tags improve search engine optimization (SEO), enhance social media
+sharing, and aid in accessibility.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-application-name.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-application-name.md
@@ -1,0 +1,12 @@
+---
+name: Meta Application Name
+site-quality-control-id: 1
+description: HTML meta tags must include an application-name for web apps.
+property-name: application-name
+impact: Missing application name may impact the app-like behavior of the website on mobile devices.
+suggested-solution: Include the application name meta tag to optimize the site for web app usage on mobile devices.
+---
+
+The application-name tag is especially useful for mobile web apps, providing the
+name displayed when the app is added to the home screen. This tag enhances
+branding for web applications accessed through mobile devices.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-author.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-author.md
@@ -1,0 +1,12 @@
+---
+name: Meta Author
+site-quality-control-id: 1
+description: HTML meta tags must include the author's name for authorship.
+property-name: author
+impact: Missing author can reduce trust in the content and affect SEO.
+suggested-solution: Specify the author's name to improve trust and SEO for the page.
+---
+
+Specify the author's name, especially for blogs or opinion pieces, to attribute
+the content properly. This is generally used for transparency and may improve
+trust, especially for personal or professional publications.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-charset.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-charset.md
@@ -1,0 +1,13 @@
+---
+name: Meta Charset
+site-quality-control-id: 1
+description: HTML meta tags must include the charset specification.
+property-name: charset
+impact: Missing charset can cause incorrect rendering of text, especially for non-Latin languages.
+suggested-solution: Specify the charset, such as UTF-8, to ensure proper character encoding and text display.
+---
+
+Define the character encoding using "UTF-8" to support various languages and
+symbols, ensuring proper rendering of text across devices. The charset tag
+should be placed within the <head> section and ideally be one of the first tags
+to load for consistent encoding.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-content.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-content.md
@@ -1,0 +1,13 @@
+---
+name: Meta Content
+site-quality-control-id: 1
+description: HTML meta tags must include content for description, keywords, etc.
+property-name: content
+impact: Missing content can reduce search engine visibility and mislead users.
+suggested-solution: Ensure that every meta tag includes appropriate content (e.g., description, keywords) relevant to the page.
+---
+
+Each <meta> tag with a name attribute (like description or keywords) should
+include relevant content.For example, the description content should provide a
+summary of the page in about 150 characters, while keywords should be specific
+to the content.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-description.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-description.md
@@ -1,0 +1,12 @@
+---
+name: Meta Description
+site-quality-control-id: 1
+description: HTML meta tags must include a description tag for SEO.
+property-name: description
+impact: Missing description can impact search engine rankings and user click-through rates.
+suggested-solution: Add a concise description of the page (70-160 characters) to improve SEO and user engagement.
+---
+
+The description tag should provide a concise, compelling summary of the page
+within 70-160 characters. This is often displayed as a snippet in search
+results, so make it informative and engaging to encourage clicks.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-generator.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-generator.md
@@ -1,0 +1,12 @@
+---
+name: Meta Generator
+site-quality-control-id: 1
+description: HTML meta tags must include a generator tag specifying the CMS.
+property-name: generator
+impact: Missing generator can lead to confusion about the site's platform.
+suggested-solution: Include a generator tag specifying the CMS used (e.g., WordPress, Drupal).
+---
+
+The generator tag specifies the software or CMS used to create the page (e.g.,
+"WordPress 5.8", "Drupal 9"). This helps with support and troubleshooting,
+though it can sometimes pose a security risk if outdated versions are disclosed.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-http-equiv.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-http-equiv.md
@@ -1,0 +1,13 @@
+---
+name: Meta Http-Equiv
+site-quality-control-id: 1
+description: HTML meta tags must include http-equiv to define HTTP headers.
+property-name: http-equiv
+impact: Missing http-equiv meta tags can lead to improper HTTP header settings.
+suggested-solution: Include http-equiv meta tags to define Content-Type, browser compatibility, and security headers effectively.
+---
+
+Use http-equiv to set HTTP headers in HTML, such as Content-Type,
+X-UA-Compatible, and Content-Security-Policy. The most common use is setting the
+Content-Type as "text/html; charset=UTF-8". This can also control browser
+compatibility and security.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-keywords.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-keywords.md
@@ -1,0 +1,13 @@
+---
+name: Meta Keywords
+site-quality-control-id: 1
+description: HTML meta tags must include relevant keywords.
+property-name: keywords
+impact: Missing keywords may affect search engine optimization (SEO).
+suggested-solution: Include relevant keywords in the meta tag to improve SEO and discoverability.
+---
+
+List relevant keywords in a comma-separated format to highlight key topics of
+the page. Although not heavily used by search engines, it can provide extra
+context in some cases. Include specific terms relevant to the page’s content,
+ideally around 5-10 keywords.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-robots.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-robots.md
@@ -1,0 +1,13 @@
+---
+name: Meta Robots
+site-quality-control-id: 1
+description: HTML meta tags must include robots directive for search engines.
+property-name: robots
+impact: Missing robots tag can result in unwanted pages being indexed by search engines.
+suggested-solution: Add a robots meta tag to control which pages are indexed by search engines.
+---
+
+The robots tag helps control page indexing with directives like "index, follow"
+or "noindex, nofollow". Common settings include "noindex" to prevent indexing or
+"nofollow" to disallow link following, controlling how search engines interact
+with the page.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-title.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-title.md
@@ -1,0 +1,13 @@
+---
+name: Meta Title
+site-quality-control-id: 1
+description: The title tag, if used, is generally intended to provide additional metadata about the title rather than set the primary title itself.
+property-name: title
+impact: If the title is missing, it typically has no direct impact, as <meta name="title"> is rarely recognized for SEO or social sharing.
+suggested-solution: Ensure that every meta tag includes a name attribute for proper metadata interpretation.
+---
+
+The <title> tag is the standard way to define the primary title of the page. If
+using <meta name="title">, it should complement, not replace, the primary title.
+Avoid using <meta name="title"> as the main title, as it is not widely supported
+and does not affect SEO or social media visibility.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-viewport.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/html-meta-tags/policies/meta-viewport.md
@@ -1,0 +1,13 @@
+---
+name: Meta Viewport
+site-quality-control-id: 1
+description: HTML meta tags must include a viewport specification for mobile.
+property-name: viewport
+impact: Missing viewport tag can cause the website to appear incorrectly on mobile devices.
+suggested-solution: Add the viewport meta tag to ensure the site is properly displayed on mobile devices.
+---
+
+The viewport tag ensures proper scaling on mobile devices. A common setup is
+"width=device-width, initial-scale=1.0", allowing the content to fit within the
+device screen. This is essential for responsive design, enabling the website to
+adapt to varying screen sizes.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/control.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/control.md
@@ -1,0 +1,13 @@
+---
+site-quality-control-id: 2
+name: Open Graph Metadata
+fii: FII-SQE-SEO-OGM-0001
+---
+
+Open Graph metadata is a set of HTML meta tags used to control how web page
+content appears when shared on social media platforms. Developed by Facebook,
+the Open Graph protocol enables web pages to become "rich" objects, providing
+specific data points like title, description, and images, which enhance link
+previews and improve engagement. Placed within the <head> section, Open Graph
+tags provide consistency across platforms and ensure that shared links appear
+professional and informative.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-description.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-description.md
@@ -1,0 +1,14 @@
+---
+name: OG Description
+site-quality-control-id: 2
+description: Open Graph metadata must include a description for context.
+property-name: og:description
+impact: Missing description can lead to unclear social media previews, decreasing user engagement.
+suggested-solution: Add a brief and relevant description in the Open Graph metadata tag for better content
+---
+
+The OG description provides a brief, compelling summary of the content, aiming
+to attract viewers. The ideal length is between 70-200 characters, providing
+essential details to help users decide whether to engage with the content. Avoid
+generic language and focus on unique value propositions or key points from the
+page to maximize clicks and shares.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-image.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-image.md
@@ -1,0 +1,15 @@
+---
+name: OG Image
+site-quality-control-id: 2
+description: Open Graph metadata must include an image URL.
+property-name: og:image
+impact: Missing image can result in content without an image, which reduces engagement.
+suggested-solution: Provide a valid image URL for better engagement on social platforms.
+---
+
+The OG image provides a visual representation for the shared content. It should
+be a high-quality image relevant to the content, ideally with a minimum
+resolution of 1200x630 pixels and a 1.91:1 aspect ratio. JPEG or PNG formats are
+preferred, and the file size should be under 5MB for optimal loading. This image
+will appear in the link preview, attracting user attention and enhancing
+engagement.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-locale.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-locale.md
@@ -1,0 +1,14 @@
+---
+name: OG Locale
+site-quality-control-id: 2
+description: Open Graph metadata must specify the locale.
+property-name: og:locale
+impact: Missing locale may affect the targeting of localized audiences.
+suggested-solution: Specify the appropriate locale in the Open Graph metadata for regional targeting.
+---
+
+The OG locale tag defines the regional language of the content in the format
+language-region (e.g., en_US for U.S. English, es_ES for Spain Spanish). This
+helps social platforms target the correct audience by language and location,
+enhancing relevance. Specify the locale to ensure the page appears correctly to
+users from different regions.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-site-name.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-site-name.md
@@ -1,0 +1,14 @@
+---
+name: OG Site Name
+site-quality-control-id: 2
+description: Open Graph metadata must include the site name.
+property-name: og:site_name
+impact: Missing site name could impact site identity and recognition on social platforms.
+suggested-solution: Ensure that the Open Graph metadata includes your website's name for better brand recognition.
+---
+
+The OG site name provides context on the origin of the content, helping build
+brand recognition on social platforms. It should match the website's brand or
+name, adding authority and trust to the shared content. Users are more likely to
+engage with recognizable and trusted sources, making this a crucial tag for
+brand consistency.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-title.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-title.md
@@ -1,0 +1,15 @@
+---
+name: OG Title
+site-quality-control-id: 2
+description: Open Graph metadata must include a title for social sharing.
+property-name: og:title
+impact: Missing title can affect the site's appearance in social media previews.
+suggested-solution: Add a meaningful title to the Open Graph metadata tag to ensure a proper social media preview.
+---
+
+The OG title is crucial for social sharing, as it serves as the headline when
+the content is shared on social platforms. It should be descriptive, concise,
+and attention-grabbing to encourage user engagement. Optimal length is between
+30-60 characters. Avoid generic titles and make it unique and specific to the
+content. If the content changes, consider updating the title to reflect the most
+current context.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-type.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-type.md
@@ -1,0 +1,14 @@
+---
+name: OG Type
+site-quality-control-id: 2
+description: Open Graph metadata must include a type for the content.
+property-name: og:type
+impact: Missing type can lead to improper rendering of the page in social media previews.
+suggested-solution: Specify the correct content type (e.g., website or article) in the Open Graph metadata tag.
+---
+
+The OG type defines the nature of the content (e.g., "website" for a homepage or
+"article" for blog posts). Common types include "article" (for news articles,
+blogs), "website" (for general pages), "product" (for e-commerce products), and
+"video" (for media). Correct specification of type ensures optimal rendering on
+social platforms and helps them categorize content correctly.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-updated-time.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-updated-time.md
@@ -1,0 +1,14 @@
+---
+name: OG Updated Time
+site-quality-control-id: 2
+description: Open Graph metadata should include the last updated time.
+property-name: og:updated_time
+impact: Missing updated time may reduce trust and freshness perception on social media.
+suggested-solution: Include the updated time in ISO 8601 format to signal content freshness.
+---
+
+The OG updated time signals the freshness of the content to users, often
+displayed as "last updated" on social platforms. It should follow the ISO 8601
+format (e.g., 2024-11-01T10:00:00Z), indicating the date and time the content
+was last modified. This helps users understand if the information is current and
+relevant, which can increase trust and engagement.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-url.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/open-graph-meta-data/policies/og-url.md
@@ -1,0 +1,14 @@
+---
+name: OG URL
+site-quality-control-id: 2
+description: Open Graph metadata must include a URL for the content.
+property-name: og:url
+impact: Missing URL may cause issues with sharing the page correctly on social platforms.
+suggested-solution: Ensure that the URL in the Open Graph metadata points to the correct page or content.
+---
+
+The OG URL specifies the link to the content, which is critical for proper page
+redirection and tracking. This URL should be the canonical URL of the content
+page, without unnecessary query parameters or fragments. It ensures that all
+shares lead back to a single URL, which helps with SEO and consistent social
+shares.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/control.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/control.md
@@ -1,0 +1,9 @@
+---
+site-quality-control-id: 3
+name: Twitter Card Metadata
+fii: FII-SQE-SEO-TCM-0001
+---
+
+Twitter Card metadata enables web pages to display rich content when shared on
+Twitter. By adding specific meta tags, you can control how your content appears
+on Twitter, improving engagement and click-through rates.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-card-type.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-card-type.md
@@ -1,0 +1,13 @@
+---
+name: Twitter Card Type
+site-quality-control-id: 3
+description: Twitter metadata must include a card type.
+property-name: twitter:card
+impact: Missing card type can result in improper content display on Twitter.
+suggested-solution: Ensure that a correct Twitter card type is defined, such as "summary" or "summary_large_image".
+---
+
+The Twitter card type defines how the content is displayed on Twitter. Common
+card types include "summary" (for basic text and images), "summary_large_image"
+(for larger images), and "player" (for embedded media). Specifying the correct
+card type ensures that the content displays optimally.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-description.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-description.md
@@ -1,0 +1,11 @@
+---
+name: Twitter Description
+site-quality-control-id: 3
+description: Twitter Card metadata should provide a description for context.
+property-name: twitter:description
+impact: Missing description may reduce engagement by providing less context on Twitter.
+suggested-solution: Include a brief and meaningful description to improve user engagement on Twitter.
+---
+
+The description should offer context within 70-200 characters, giving a summary
+that attracts interest without overwhelming the user.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-image.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-image.md
@@ -1,0 +1,12 @@
+---
+name: Twitter Image
+site-quality-control-id: 3
+description: Twitter metadata must include an image URL for sharing.
+property-name: twitter:image
+impact: Missing image can result in poor content visibility on Twitter.
+suggested-solution: Include a relevant image URL for better visibility and engagement on Twitter.
+---
+
+The Twitter image is crucial for enhancing content visibility on Twitter. It
+should be a high-resolution image, ideally 1200x675 pixels, and under 5MB in
+size. The image should be relevant to the content and visually appealing.

--- a/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-title.md
+++ b/lib/pattern/site-quality-explorer/content/site-quality-controls/twitter-card-meta-data/policies/twitter-title.md
@@ -1,0 +1,12 @@
+---
+name: Twitter Title
+site-quality-control-id: 3
+description: Twitter metadata must include a title for sharing.
+property-name: twitter:title
+impact: Missing title can result in a poor social preview and lower engagement.
+suggested-solution: Add an appropriate title for better engagement when shared on Twitter.
+---
+
+The Twitter title is important for creating a preview when the content is shared
+on Twitter. It should be descriptive, engaging, and between 70-100 characters.
+Ensure the title aligns with the content and encourages users to click.

--- a/lib/pattern/site-quality-explorer/deps.ts
+++ b/lib/pattern/site-quality-explorer/deps.ts
@@ -1,0 +1,2 @@
+export * from "../../std/deps.ts";
+export { sqlPageNB } from "../../std/notebook/mod.ts";

--- a/lib/pattern/site-quality-explorer/package.sql.ts
+++ b/lib/pattern/site-quality-explorer/package.sql.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run --allow-sys --allow-net
+import { sqlPageNB as spn } from "./deps.ts";
+import {
+  console as c,
+  orchestration as orch,
+  shell as sh,
+  uniformResource as ur,
+} from "../../std/web-ui-content/mod.ts";
+
+// custom decorator that makes navigation for this notebook type-safe
+function sqNav(route: Omit<spn.RouteConfig, "path" | "parentPath">) {
+  return spn.navigationPrime({
+    ...route,
+    parentPath: "/dms",
+  });
+}
+
+/**
+ * These pages depend on ../../prime/ux.sql.ts being loaded into RSSD (for nav).
+ */
+export class SiteQualitySqlPages extends spn.TypicalSqlPageNotebook {
+  // TypicalSqlPageNotebook.SQL injects any method that ends with `DQL`, `DML`,
+  // or `DDL` as general SQL before doing any upserts into sqlpage_files.
+  navigationDML() {
+    return this.SQL`
+      -- delete all /ip-related entries and recreate them in case routes are changed
+      DELETE FROM sqlpage_aide_navigation WHERE path like '/ce%';
+      ${this.upsertNavSQL(...Array.from(this.navigation.values()))}
+    `;
+  }
+
+  @spn.navigationPrimeTopLevel({
+    caption: "Site Quality",
+    description:
+      `The Site Quality Explorer (SQE) is a surveilr pattern designed for conducting detailed and ongoing audits of website content quality. It helps analyze how web pages perform across several key SEO factors, providing actionable insights for improving search engine rankings. SQE integrates with surveilr, leveraging its robust ingestion framework to capture and store web content across multiple sources. It uses SQLite and Full Text Search(FTS) to perform efficient queries and generate important SEO metrics`,
+  })
+  "sq/index.sql"() {
+    return this.SQL`
+    SELECT
+    'card' AS component,
+    'Website Resources' AS title,  -- Section title for the card layout
+    3 AS columns;  -- Number of columns, adjust based on desired layout
+
+    -- Dynamically create a card for each entry in uniform_resource_website
+    SELECT
+      hostname AS title,
+      'missing-meta-information.sql?hostname='||hostname||'' AS link,           -- Description from the table
+      'world' AS icon,             -- Icon for each card (use any icon you like)
+      'blue' AS color              -- Card color, adjust as desired
+    FROM
+      uniform_resource_website WHERE hostname not like '%www.%';`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "sq/missing-meta-information.sql"() {
+    return this.SQL`
+    SELECT
+      'breadcrumb' AS component;
+    SELECT
+      'Home' AS title,
+      '/'    AS link;
+    SELECT
+      'Website Resources' AS title,
+      '/sq' AS link;
+
+    SELECT
+    'title' AS component,
+    'Social Media and SEO Metadata Analysis for: '||$hostname::TEXT ||'' as contents,
+    3 AS level;
+
+    SELECT
+    'title' AS component,
+    ''||name||': '||description||'' as contents,
+    5 AS level
+    FROM site_quality_control;
+
+    SELECT
+      'card' AS component,
+      '' AS title,
+      2 AS columns;
+
+    SELECT
+      'Open Graph Missing Properties Overview' AS title,
+      GROUP_CONCAT(
+        '**' || property_name || ' missing URLs:** ' ||
+        ' [ ' || missing_count || ' ](missing-meta-information/details.sql?hostname=' || $hostname || '&property=' || property_name ||') ' || '  \n\n',
+        ''
+      ) AS description_md,
+      'tag' AS icon,
+      'green' AS color
+    FROM (
+      SELECT
+        property_name,
+        COUNT(*) AS missing_count
+      FROM uniform_resource_uri_missing_open_graph
+      WHERE uri LIKE '%' || $hostname::TEXT || '%'
+      GROUP BY property_name
+    );
+
+    SELECT
+      'HTML Meta Missing Properties Overview' AS title,
+      GROUP_CONCAT(
+        '**' || property_name || ' missing URLs:** ' ||
+        ' [ ' || missing_count || ' ](missing-meta-information/details.sql?hostname=' || $hostname || '&property=' || property_name ||') ' || '  \n\n',
+        ''
+      ) AS description_md,
+      'tag' AS icon,
+      'orange' AS color
+    FROM (
+      SELECT
+        property_name,
+        COUNT(*) AS missing_count
+      FROM uniform_resource_uri_missing_html_meta_data
+      WHERE uri LIKE '%' || $hostname::TEXT || '%'
+      GROUP BY property_name
+    );
+
+    SELECT
+      'Twitter Card Missing Properties Overview' AS title,
+      GROUP_CONCAT(
+        '**' || property_name || ' missing URLs:** ' ||
+        ' [ ' || missing_count || ' ](missing-meta-information/details.sql?hostname=' || $hostname || '&property=' || property_name ||') ' || '  \n\n',
+        ''
+      ) AS description_md,
+      'tag' AS icon,
+      'blue' AS color
+    FROM (
+      SELECT
+        property_name,
+        COUNT(*) AS missing_count
+      FROM uniform_resource_uri_missing_twitter_card_cached
+      WHERE uri LIKE '%' || $hostname::TEXT || '%'
+      GROUP BY property_name
+    );
+  `;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "sq/missing-meta-information/details.sql"() {
+    const viewName = `uniform_resource_uri_missing_meta_info`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL:
+        "WHERE property_name=$property::TEXT AND uri LIKE '%'||$hostname::TEXT||'%'",
+    });
+    return this.SQL`
+    SELECT
+      'breadcrumb' AS component;
+    SELECT
+      'Home' AS title,
+      '/'    AS link;
+    SELECT
+      'Website Resources' AS title,
+      '/sq' AS link;
+    SELECT
+      'Social Media and SEO Metadata Analysis' AS title,
+      '/sq/missing-meta-information.sql?hostname='||$hostname::TEXT||'' AS link;
+    ${pagination.init()}
+
+    SELECT
+      'text' AS component,
+      '**Property Name:** ' || property_name || '  \n' ||
+      '**Description:** ' || description || '  \n' ||
+      '**Requirements:** ' || requirement || '  \n' ||
+      '**Impact of Missing Property:** ' || impact || '  \n' ||
+      '**Suggested Solution:** ' || suggested_solution || '  \n'
+      AS contents_md
+    FROM
+      site_quality_policy
+    WHERE
+      property_name = $property::TEXT;
+
+    SELECT
+    'title' AS component,
+    'URLs Missing the Property "'||$property::TEXT||'" for: '||$hostname::TEXT||'' as contents,
+    3 AS level;
+
+    SELECT
+    'table' AS component,
+    TRUE AS sort,
+    TRUE AS search;
+    SELECT
+      ROW_NUMBER() OVER () AS "Sl.No",
+      uri   AS "Website URL"
+      FROM uniform_resource_uri_missing_meta_info WHERE property_name=$property::TEXT AND uri LIKE '%'||$hostname::TEXT||'%'
+      LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown()};
+    `;
+  }
+
+  @sqNav({
+    caption: "Mising Meta Data",
+    description: "Mising Meta Data",
+    siblingOrder: 4,
+  })
+  "sq/missing-meta-data.sql"() {
+    return this.SQL`
+    -- Define tabs
+    SELECT
+      'tab' AS component,
+      TRUE AS center;
+
+    -- Tab 1: Open Graph Missing URLs
+    SELECT
+      'Open Graph Missing URLs' AS title,
+      '/sq/missing-meta-data.sql?hostname=' || $hostname::TEXT || '&tab=open_graph' AS link,
+      $tab = 'open_graph' AS active;
+
+    -- Tab 2: Meta Tags Missing URLs
+    SELECT
+      'Meta Tags Missing URLs' AS title,
+      '/sq/missing-meta-data.sql?hostname=' || $hostname::TEXT || '&tab=html_meta_data' AS link,
+      $tab = 'html_meta_data' AS active;
+
+    -- Define component type based on active tab
+    SELECT
+      CASE
+        WHEN $tab = 'open_graph' THEN 'table'
+        WHEN $tab = 'html_meta_data' THEN 'table'
+      END AS component,TRUE AS sort,TRUE AS search,'URL' AS align_left,'Property Name' AS align_left;
+
+    -- Conditional content based on active tab
+    -- Tab-specific content for "open_graph"
+    SELECT
+      property_name AS "Property Name",uri AS "URL"
+    FROM uniform_resource_uri_missing_open_graph
+    WHERE $tab = 'open_graph'
+    AND uri LIKE '%' || $hostname::TEXT || '%';
+
+    -- Tab-specific content for "html_meta_data"
+    SELECT
+      uri AS "URL", property_name AS "Property Name"
+    FROM uniform_resource_uri_missing_html_meta_data
+    WHERE $tab = 'html_meta_data'
+    AND uri LIKE '%' || $hostname::TEXT || '%';
+    `;
+  }
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+
+export async function controlSQL() {
+  return await spn.TypicalSqlPageNotebook.SQL(
+    new class extends spn.TypicalSqlPageNotebook {
+      async statelessControlSQL() {
+        // read the file from either local or remote (depending on location of this file)
+        return await spn.TypicalSqlPageNotebook.fetchText(
+          import.meta.resolve("./stateless.sql"),
+        );
+      }
+
+      async orchestrateStatefulControlSQL() {
+        // read the file from either local or remote (depending on location of this file)
+        return await spn.TypicalSqlPageNotebook.fetchText(
+          import.meta.resolve("./stateful.sql"),
+        );
+      }
+    }(),
+    new sh.ShellSqlPages(),
+    new c.ConsoleSqlPages(),
+    new ur.UniformResourceSqlPages(),
+    new orch.OrchestrationSqlPages(),
+    new SiteQualitySqlPages(),
+  );
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+  console.log((await controlSQL()).join("\n"));
+}

--- a/lib/pattern/site-quality-explorer/stateful.sql
+++ b/lib/pattern/site-quality-explorer/stateful.sql
@@ -1,0 +1,55 @@
+DROP TABLE IF EXISTS uniform_resource_image_cached;
+CREATE TABLE uniform_resource_image_cached AS SELECT * FROM uniform_resource_image;
+
+DROP TABLE IF EXISTS uniform_resource_link_cached;
+CREATE TABLE uniform_resource_link_cached AS SELECT * FROM uniform_resource_link;
+
+DROP TABLE IF EXISTS uniform_resource_text_element_cached;
+CREATE TABLE uniform_resource_text_element_cached AS SELECT * FROM uniform_resource_text_element;
+
+DROP TABLE IF EXISTS uniform_resource_open_graph_cached;
+CREATE TABLE uniform_resource_open_graph_cached AS SELECT * FROM uniform_resource_open_graph;
+
+DROP TABLE IF EXISTS uniform_resource_html_meta_data_cached;
+CREATE TABLE uniform_resource_html_meta_data_cached AS SELECT * FROM uniform_resource_html_meta_data;
+
+DROP TABLE IF EXISTS uniform_resource_twitter_card_cached;
+CREATE TABLE uniform_resource_twitter_card_cached AS SELECT * FROM uniform_resource_twitter_card;
+
+DROP TABLE IF EXISTS uniform_resource_facebook_app_cached;
+CREATE TABLE uniform_resource_facebook_app_cached AS SELECT * FROM uniform_resource_facebook_app;
+
+DROP TABLE IF EXISTS uniform_resource_dublin_core_cached;
+CREATE TABLE uniform_resource_dublin_core_cached AS SELECT * FROM uniform_resource_dublin_core;
+
+DROP TABLE IF EXISTS uniform_resource_schema_org_cached;
+CREATE TABLE uniform_resource_schema_org_cached AS SELECT * FROM uniform_resource_schema_org;
+
+DROP TABLE IF EXISTS uniform_resource_apple_cached;
+CREATE TABLE uniform_resource_apple_cached AS SELECT * FROM uniform_resource_apple;
+
+DROP TABLE IF EXISTS uniform_resource_social_media_cached;
+CREATE TABLE uniform_resource_social_media_cached AS SELECT * FROM uniform_resource_social_media;
+
+DROP TABLE IF EXISTS uniform_resource_uri_missing_open_graph_cached;
+CREATE TABLE uniform_resource_uri_missing_open_graph_cached AS SELECT * FROM uniform_resource_uri_missing_open_graph;
+
+DROP TABLE IF EXISTS uniform_resource_uri_missing_html_meta_data_cached;
+CREATE TABLE uniform_resource_uri_missing_html_meta_data_cached AS SELECT * FROM uniform_resource_uri_missing_html_meta_data;
+
+DROP TABLE IF EXISTS uniform_resource_uri_missing_twitter_card_cached;
+CREATE TABLE uniform_resource_uri_missing_twitter_card_cached AS SELECT * FROM uniform_resource_uri_missing_twitter_card;
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/pattern/site-quality-explorer/stateless.sql
+++ b/lib/pattern/site-quality-explorer/stateless.sql
@@ -1,0 +1,299 @@
+
+DROP VIEW IF EXISTS site_quality_control;
+CREATE VIEW site_quality_control AS
+SELECT
+  uniform_resource_id,
+  uri,
+  json_extract(frontmatter, '$.site-quality-control-id') AS site_quality_control_id,
+  json_extract(frontmatter, '$.name') AS name,
+  json_extract(frontmatter, '$.fii') AS fii,
+  TRIM(
+    SUBSTR(
+      json_extract(content_fm_body_attrs, '$.body'),
+      INSTR(json_extract(content_fm_body_attrs, '$.body'), '\n') + 1
+    )
+  ) AS description
+FROM
+  uniform_resource
+WHERE
+  uri LIKE '%control.md';
+
+DROP VIEW IF EXISTS site_quality_policy;
+CREATE VIEW site_quality_policy AS
+SELECT
+  uniform_resource_id,
+  uri,
+  json_extract(frontmatter, '$.site-quality-control-id') AS site_quality_control_id,
+  json_extract(frontmatter, '$.name') AS name,
+  json_extract(frontmatter, '$.description') AS description,
+  json_extract(frontmatter, '$.property-name') AS property_name,
+  json_extract(frontmatter, '$.impact') AS impact,
+  json_extract(frontmatter, '$.suggested-solution') AS suggested_solution,
+  TRIM(
+    SUBSTR(
+      json_extract(content_fm_body_attrs, '$.body'),
+      INSTR(json_extract(content_fm_body_attrs, '$.body'), '\n') + 1
+    )
+  ) AS requirement
+FROM
+  uniform_resource
+WHERE
+  uri NOT LIKE '%control.md' AND uri LIKE '%site-quality-explorer/content/site-quality-controls%';
+
+DROP VIEW IF EXISTS uniform_resource_website;
+CREATE VIEW uniform_resource_website AS
+SELECT DISTINCT
+    SUBSTR(
+        ur.uri,
+        INSTR(ur.uri, 'site-quality-explorer/content/website-resources/') + LENGTH('site-quality-explorer/content/website-resources/'),
+        INSTR(SUBSTR(ur.uri, INSTR(ur.uri, 'site-quality-explorer/content/website-resources/') + LENGTH('site-quality-explorer/content/website-resources/')), '/') - 1
+    ) AS hostname,
+    MAX(CASE WHEN urogc.property_name = 'og:title' THEN urogc.content END) AS title,
+    MAX(CASE WHEN urogc.property_name = 'og:description' THEN urogc.content END) AS description
+FROM
+    uniform_resource ur
+LEFT JOIN
+    uniform_resource_open_graph_cached urogc ON ur.uri = urogc.uri
+WHERE
+    ur.uri LIKE '%site-quality-explorer/content/website-resources/%' AND ur.uri NOT LIKE '%.md%'
+GROUP BY
+    hostname;
+
+DROP VIEW IF EXISTS uniform_resource_image;
+CREATE VIEW IF NOT EXISTS uniform_resource_image AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'img', 'src') AS src,  -- Directly gets src attribute
+  html_attr_get(h.html, 'img', 'alt') AS alt,  -- Directly gets alt attribute
+  h.html                                       -- Full HTML of the img element
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'img') AS h;
+
+DROP VIEW IF EXISTS uniform_resource_link;
+CREATE VIEW IF NOT EXISTS uniform_resource_link AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'a', 'href') AS href,
+  h.text,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'a') AS h;
+
+DROP VIEW IF EXISTS uniform_resource_text_element;
+CREATE VIEW IF NOT EXISTS uniform_resource_text_element AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  substr(h.html, 2, instr(h.html, '>') - 2) AS tag,  -- Extracts the tag name
+  h.text,                                            -- Text content of the element
+  h.html                                             -- Full HTML of the element
+FROM
+  uniform_resource AS u,
+  html_each(u.content, '*') AS h
+WHERE
+  substr(h.html, 2, instr(h.html, '>') - 2) IN ('p', 'li', 'span', 'h1', 'h2', 'h3');
+
+DROP VIEW IF EXISTS uniform_resource_open_graph;
+CREATE VIEW IF NOT EXISTS uniform_resource_open_graph AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'property') AS property_name,   -- Extracts the Open Graph property name
+  html_attr_get(h.html, 'meta', 'content') AS content,          -- Extracts the content of the property
+  h.html AS html                                                -- Full HTML of the meta tag
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta') AS h
+WHERE
+  html_attr_get(h.html, 'meta', 'property') LIKE 'og:%'          -- Filters for Open Graph properties
+  AND html_attr_get(h.html, 'meta', 'content') IS NOT NULL AND u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_html_meta_data;
+CREATE VIEW uniform_resource_html_meta_data AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  'title' AS property_name,  -- Explicitly set property_name to 'title'
+  html_text(u.content, 'title') AS content,  -- Extract content of the <title> tag
+  html_extract(u.content,'title') AS html
+FROM
+  uniform_resource AS u WHERE u.uri LIKE '%.html%'
+UNION ALL
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'name') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta') AS h
+WHERE
+  -- Exclude Open Graph, Twitter Cards, etc.
+  html_attr_get(h.html, 'meta', 'name') NOT LIKE 'og:%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'twitter:%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'fb:%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'DC.%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'apple-%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'schema.org'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'pinterest%'
+  AND html_attr_get(h.html, 'meta', 'name') NOT LIKE 'linkedin%'
+  AND u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_twitter_card;
+CREATE VIEW uniform_resource_twitter_card AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'name') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta[name^="twitter:"]') AS h
+  WHERE u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_facebook_app;
+CREATE VIEW uniform_resource_facebook_app AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'property') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta[property^="fb:"]') AS h
+  WHERE u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_dublin_core;
+CREATE VIEW uniform_resource_dublin_core AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'name') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta[name^="DC."]') AS h
+  WHERE u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_schema_org;
+CREATE VIEW uniform_resource_schema_org AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  'schema.org' AS property_name,
+  h.html AS content,  -- Full JSON-LD content
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'script[type="application/ld+json"]') AS h;
+
+DROP VIEW IF EXISTS uniform_resource_apple;
+CREATE VIEW uniform_resource_apple AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'name') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta[name^="apple-"]') AS h
+  WHERE u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_social_media;
+CREATE VIEW uniform_resource_social_media AS
+SELECT
+  u.uniform_resource_id AS uniform_resource_id,
+  u.uri,
+  html_attr_get(h.html, 'meta', 'name') AS property_name,
+  html_attr_get(h.html, 'meta', 'content') AS content,
+  h.html
+FROM
+  uniform_resource AS u,
+  html_each(u.content, 'meta[name^="pinterest"], meta[name^="linkedin"]') AS h
+  WHERE u.uri LIKE '%.html%';
+
+DROP VIEW IF EXISTS uniform_resource_uri_missing_open_graph;
+CREATE VIEW uniform_resource_uri_missing_open_graph AS
+WITH required_properties AS (
+  SELECT 'og:title' AS property_name
+  UNION ALL SELECT 'og:description'
+  UNION ALL SELECT 'og:image'
+  UNION ALL SELECT 'og:url'
+  -- You can add more properties as needed
+)
+SELECT DISTINCT
+  SUBSTR(u.uri, INSTR(u.uri, 'site-quality-explorer/content/website-resources/') + LENGTH('site-quality-explorer/content/website-resources/')) AS uri,
+  rp.property_name
+FROM
+  uniform_resource AS u
+  CROSS JOIN required_properties AS rp
+LEFT JOIN
+  (SELECT uniform_resource_id, property_name,content FROM uniform_resource_open_graph_cached) AS og
+  ON u.uniform_resource_id = og.uniform_resource_id
+  AND rp.property_name = og.property_name
+WHERE
+  u.uri LIKE '%.html%' AND (og.property_name IS NULL OR og.content IS NULL);
+
+DROP VIEW IF EXISTS uniform_resource_uri_missing_html_meta_data;
+CREATE VIEW uniform_resource_uri_missing_html_meta_data AS
+WITH required_properties AS (
+  SELECT 'description' AS property_name
+  UNION ALL SELECT 'keywords'
+  UNION ALL SELECT 'author'
+  UNION ALL SELECT 'robots'
+  UNION ALL SELECT 'viewport'
+  UNION ALL SELECT 'title'
+  -- You can add more required meta properties as needed
+)
+SELECT DISTINCT
+ SUBSTR(u.uri, INSTR(u.uri, 'site-quality-explorer/content/website-resources/') + LENGTH('site-quality-explorer/content/website-resources/')) AS uri,
+ rp.property_name
+FROM
+  uniform_resource AS u
+  CROSS JOIN required_properties AS rp
+LEFT JOIN
+  (SELECT uniform_resource_id, property_name,content FROM uniform_resource_html_meta_data_cached) AS hmd
+  ON u.uniform_resource_id = hmd.uniform_resource_id
+  AND rp.property_name = hmd.property_name
+WHERE
+  u.uri LIKE '%.html%' AND (hmd.property_name IS NULL OR hmd.content IS NULL);
+
+DROP VIEW IF EXISTS uniform_resource_uri_missing_twitter_card;
+CREATE VIEW uniform_resource_uri_missing_twitter_card AS
+WITH required_properties AS (
+  SELECT 'twitter:card' AS property_name
+  UNION ALL SELECT 'twitter:title'
+  UNION ALL SELECT 'twitter:description'
+  UNION ALL SELECT 'twitter:image'
+  -- You can add more properties as needed
+)
+SELECT DISTINCT
+  SUBSTR(u.uri, INSTR(u.uri, 'site-quality-explorer/content/website-resources/') + LENGTH('site-quality-explorer/content/website-resources/')) AS uri,
+  rp.property_name
+FROM
+  uniform_resource AS u
+  CROSS JOIN required_properties AS rp
+LEFT JOIN
+  (SELECT uniform_resource_id, property_name,content FROM uniform_resource_twitter_card_cached) AS tc
+  ON u.uniform_resource_id = tc.uniform_resource_id
+  AND rp.property_name = tc.property_name
+WHERE
+  u.uri LIKE '%.html%' AND (tc.property_name IS NULL OR tc.content IS NULL);
+
+DROP VIEW IF EXISTS uniform_resource_uri_missing_meta_info;
+CREATE VIEW uniform_resource_uri_missing_meta_info AS
+SELECT * FROM uniform_resource_uri_missing_open_graph
+UNION ALL
+SELECT * FROM uniform_resource_uri_missing_html_meta_data
+UNION ALL
+SELECT * FROM uniform_resource_uri_missing_twitter_card;
+


### PR DESCRIPTION
This pull request introduces a new pattern for Site Quality, focusing on Social Media Metadata and Document Metadata. The following updates have been made:

1. Social Media Metadata and Document Metadata controls and policies have been defined as markdown files. These markdown files provide a structured approach to evaluating the metadata of web pages.
2.  A mechanism for downloading website resources has been added using the `wget --mirror` command. This ensures that all relevant website resources are retrieved for analysis.
3. After running the `Surveilr` ingestion process, users can now view the analysis results for Social Media Metadata and Document Metadata for the downloaded website URLs. This includes extracting and presenting key metadata like `Open Graph`, `Twitter Card`, and `HTML meta tags`.

**Key Changes:**

- Created markdown files defining controls and policies for Social Media Metadata and Document Metadata.
- Added instructions for downloading website resources using `wget --mirror`.
- Integrated the Social Media Metadata and Document Metadata analysis into the Surveilr ingestion process.

**Purpose:**
This update improves the site's metadata analysis capabilities by enabling automatic extraction and evaluation of metadata that is essential for social media sharing and web page information presentation.