### PR TITLE
fix: bottom link in function inner corrected #20

### DIFF
--- a/lib/std/web-ui-content/docs.ts
+++ b/lib/std/web-ui-content/docs.ts
@@ -24,19 +24,16 @@ export class DocsSqlPages extends spn.TypicalSqlPageNotebook {
                 WITH navigation_cte AS (
                 SELECT COALESCE(title, caption) as title, description
                     FROM sqlpage_aide_navigation
-                WHERE namespace = 'prime' AND path = ${
-      this.constructHomePath("docs")
-    }
+                WHERE namespace = 'prime' AND path = ${this.constructHomePath("docs")
+      }
                 )
                 SELECT 'list' AS component, title, description
                     FROM navigation_cte;
-                SELECT caption as title, ${
-      this.absoluteURL("/")
-    } || COALESCE(url, path) as link, description
+                SELECT caption as title, ${this.absoluteURL("/")
+      } || COALESCE(url, path) as link, description
                     FROM sqlpage_aide_navigation
-                WHERE namespace = 'prime' AND parent_path =  ${
-      this.constructHomePath("docs")
-    }
+                WHERE namespace = 'prime' AND parent_path =  ${this.constructHomePath("docs")
+      }
                 ORDER BY sibling_order;
             `;
   }
@@ -265,9 +262,8 @@ export class DocsSqlPages extends spn.TypicalSqlPageNotebook {
          ${this.absoluteURL("/docs/functions.sql")} as link;
       select
         $function as title,
-        ${
-      this.absoluteURL("/docs/functions-inner.sql?function=")
-    }  || $function AS link;
+        ${this.absoluteURL("/docs/functions-inner.sql?function=")
+      }  || $function AS link;
 
 
         SELECT
@@ -307,7 +303,7 @@ export class DocsSqlPages extends spn.TypicalSqlPageNotebook {
         SELECT 'button' AS component, 'sm' AS size, 'pill' AS shape;
         SELECT name AS title,
               NULL AS icon,  -- Add an icon field if needed
-              sqlpage.link('functions.sql', json_object('function', name)) AS link
+              sqlpage.link('functions-inner.sql', json_object('function', name)) AS link
         FROM surveilr_function_doc
         ORDER BY name;
    `;


### PR DESCRIPTION
This PR fixes an issue with the bottom link in the functions-inner.sql file to ensure it points to the correct target.