### PR TITLE
fix: console info schema uniform resource view issue #20

### DIFF
--- a/lib/pattern/content-assembler/README.md
+++ b/lib/pattern/content-assembler/README.md
@@ -250,7 +250,8 @@ newsletters, such as subscription management or general content links.
 ```bash
 # load the "Console" and other menu/routing utilities plus FHIR Web UI (both are same, just run one)
 $ deno run -A ./package.sql.ts | surveilr shell   # option 1 (same as option 2)
-$ surveilr shell ./package.sql.ts                 # option 2 (same as option 1)
+$ surveilr shell ./package.sql.ts    
+$ SURVEILR_SQLPKG=~/.sqlpkg surveilr shell ./package.sql.ts             # option 2 (same as option 1)
 
 # start surveilr web-ui in "watch" mode to re-load package.sql.ts automatically
 $ SQLPAGE_SITE_PREFIX=/lib/pattern/content-assembler ../../std/surveilrctl.ts dev

--- a/lib/pattern/content-assembler/package.sql.ts
+++ b/lib/pattern/content-assembler/package.sql.ts
@@ -38,9 +38,8 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
   navigationDML() {
     return this.SQL`
       -- delete all /cak-related entries and recreate them in case routes are changed
-      DELETE FROM sqlpage_aide_navigation WHERE parent_path=${
-      this.constructHomePath("cak")
-    };
+      DELETE FROM sqlpage_aide_navigation WHERE parent_path=${this.constructHomePath("cak")
+      };
       ${this.upsertNavSQL(...Array.from(this.navigation.values()))}
     `;
   }
@@ -65,13 +64,11 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
       )
       SELECT 'list' AS component, title, description
         FROM navigation_cte;
-      SELECT caption as title, ${
-      this.absoluteURL("/")
-    } || COALESCE(url, path) as link, description
+      SELECT caption as title, ${this.absoluteURL("/")
+      } || COALESCE(url, path) as link, description
         FROM sqlpage_aide_navigation
-       WHERE namespace = 'prime' AND parent_path = ${
-      this.constructHomePath("cak")
-    }
+       WHERE namespace = 'prime' AND parent_path = ${this.constructHomePath("cak")
+      }
        ORDER BY sibling_order;`;
   }
 
@@ -146,9 +143,8 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
             'from' AS markdown;
 
        SELECT
-          '[' || message_from || ']('|| ${
-      this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
-    } || message_from || ')' AS "from",
+          '[' || message_from || ']('|| ${this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
+      } || message_from || ')' AS "from",
           subject_count as "subject count",
           periodical_count as "periodical count"
           FROM ${viewName}
@@ -178,9 +174,8 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
       SELECT
         'Periodicals' AS title,
         ${this.absoluteURL("/cak/periodicals.sql")} AS link;
-      SELECT $message_from AS title, ${
-      this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
-    }|| $message_from  AS link;
+      SELECT $message_from AS title, ${this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
+      }|| $message_from  AS link;
 
       --- Dsply Page Title
       SELECT
@@ -204,16 +199,14 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
           'removed links' AS markdown;
 
       SELECT
-        '[' || message_subject || ']('|| ${
-      this.absoluteURL(
+        '[' || message_subject || ']('|| ${this.absoluteURL(
         "/cak/periodical_anchor.sql?periodical_uniform_resource_id=",
       )
-    }  || periodical_uniform_resource_id || ')' AS "subject",
-        '[ View]('|| ${
-      this.absoluteURL(
+      }  || periodical_uniform_resource_id || ')' AS "subject",
+        '[ View]('|| ${this.absoluteURL(
         "/cak/periodical_removed_anchor.sql?periodical_uniform_resource_id=",
       )
-    } || periodical_uniform_resource_id || ') (' ||
+      } || periodical_uniform_resource_id || ') (' ||
           (SELECT
             count(anchor)
           FROM
@@ -260,17 +253,15 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
       SELECT
         'Periodicals' AS title,
         ${this.absoluteURL("/cak/periodicals.sql")} AS link;
-      SELECT message_from AS title, ${
-      this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
-    }|| message_from  AS link FROM periodicals_subject WHERE periodical_uniform_resource_id = $periodical_uniform_resource_id::TEXT;
+      SELECT message_from AS title, ${this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
+      }|| message_from  AS link FROM periodicals_subject WHERE periodical_uniform_resource_id = $periodical_uniform_resource_id::TEXT;
 
       SELECT
         message_subject as title,
-         ${
-      this.absoluteURL(
+         ${this.absoluteURL(
         "/cak/periodical_anchor.sql?periodical_uniform_resource_id=",
       )
-    }|| periodical_uniform_resource_id AS link
+      }|| periodical_uniform_resource_id AS link
       FROM
         periodicals_subject
       WHERE
@@ -301,9 +292,8 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
       SELECT
         '[' || url_text || ']('|| orginal_url ||')'   AS "original link url",
         canonical_link as 'canonical link',
-        '[ Meta Data ]('|| ${
-      this.absoluteURL("/cak/periodicals_meta.sql?url=")
-    } || orginal_url || ')' AS "meta data"
+        '[ Meta Data ]('|| ${this.absoluteURL("/cak/periodicals_meta.sql?url=")
+      } || orginal_url || ')' AS "meta data"
       FROM
         ${viewName}
       WHERE
@@ -332,9 +322,8 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
         ${this.absoluteURL("/cak/periodicals.sql")} AS link;
       SELECT
             ps.message_from AS title,
-            ${
-      this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
-    }|| ps.message_from AS link
+            ${this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
+      }|| ps.message_from AS link
             FROM
               periodicals_subject ps
             INNER JOIN periodical_anchor pa ON pa.uniform_resource_id = ps.periodical_uniform_resource_id
@@ -343,11 +332,10 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
 
       SELECT
         ps.message_subject as title,
-        ${
-      this.absoluteURL(
+        ${this.absoluteURL(
         "/cak/periodical_anchor.sql?periodical_uniform_resource_id=",
       )
-    } || ps.periodical_uniform_resource_id AS link
+      } || ps.periodical_uniform_resource_id AS link
       FROM
         periodicals_subject ps
       INNER JOIN periodical_anchor pa ON pa.uniform_resource_id = ps.periodical_uniform_resource_id
@@ -405,17 +393,15 @@ export class ContentAssemblerSqlPages extends spn.TypicalSqlPageNotebook {
       SELECT
         'Periodicals' AS title,
         ${this.absoluteURL("/cak/periodicals.sql")} AS link;
-      SELECT message_from AS title, ${
-      this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
-    }|| message_from  AS link FROM periodicals_subject WHERE periodical_uniform_resource_id = $periodical_uniform_resource_id::TEXT;
+      SELECT message_from AS title, ${this.absoluteURL("/cak/periodicals_subject.sql?message_from=")
+      }|| message_from  AS link FROM periodicals_subject WHERE periodical_uniform_resource_id = $periodical_uniform_resource_id::TEXT;
 
       SELECT
         message_subject as title,
-        ${
-      this.absoluteURL(
+        ${this.absoluteURL(
         "/cak/periodical_removed_anchor.sql?periodical_uniform_resource_id=",
       )
-    }|| periodical_uniform_resource_id AS link
+      }|| periodical_uniform_resource_id AS link
       FROM
         periodicals_subject
       WHERE
@@ -522,8 +508,8 @@ export async function SQL() {
       }
     }(),
     new sh.ShellSqlPages(SQE_TITLE, SQE_LOGO, SQE_FAV_ICON),
-    new c.ConsoleSqlPages(),
     new ur.UniformResourceSqlPages(),
+    new c.ConsoleSqlPages(),
     new orch.OrchestrationSqlPages(),
     new ContentAssemblerSqlPages(),
   );


### PR DESCRIPTION
This PR addresses an issue with viewing uniform resource views in the console info schema. The problem caused incorrect or incomplete data representation, impacting the usability and debugging experience for the uniform resource views.