### PR TITLE
refactor: removed deno code for getting version #247

### DIFF
--- a/lib/service/qualityfolio/package.auto.sql
+++ b/lib/service/qualityfolio/package.auto.sql
@@ -3541,6 +3541,6 @@ INSERT INTO sqlpage_files (path, contents, last_modified) VALUES (
                   )
               )
           ) as menu_item,
-       ''Surveilr (1.5.12)  Resource Surveillance Web UI (v'' || sqlpage.version() || '') '' || ''📄 ['' || substr(sqlpage.path(), 2) || '']('' || sqlpage.environment_variable(''SQLPAGE_SITE_PREFIX'') || ''/console/sqlpage-files/sqlpage-file.sql?path='' || substr(sqlpage.path(),LENGTH(sqlpage.environment_variable(''SQLPAGE_SITE_PREFIX'')) + 2 ) || '')'' as footer;',
+       ''Surveilr ''|| (SELECT json_extract(session_agent, ''$.version'') AS version FROM ur_ingest_session LIMIT 1) || '' Resource Surveillance Web UI (v'' || sqlpage.version() || '') '' || ''📄 ['' || substr(sqlpage.path(), 2) || '']('' || sqlpage.environment_variable(''SQLPAGE_SITE_PREFIX'') || ''/console/sqlpage-files/sqlpage-file.sql?path='' || substr(sqlpage.path(), LENGTH(sqlpage.environment_variable(''SQLPAGE_SITE_PREFIX'')) + 2 ) || '')'' as footer;',
       CURRENT_TIMESTAMP)
   ON CONFLICT(path) DO UPDATE SET contents = EXCLUDED.contents, last_modified = CURRENT_TIMESTAMP;

--- a/lib/std/web-ui-content/shell.ts
+++ b/lib/std/web-ui-content/shell.ts
@@ -1,13 +1,4 @@
 import * as spn from "../notebook/sqlpage.ts";
-
-const command = new Deno.Command("surveilr", {
-  args: ["--version"],
-});
-const { stdout } = await command.output();
-const rawOutput = new TextDecoder().decode(stdout).toString().trim();
-const versionMatch = rawOutput.match(/^surveilr\s+([\d.]+)$/i);
-const surveilrVersion = `Surveilr (${versionMatch ? versionMatch[1] : ""})`;
-
 export class ShellSqlPages extends spn.TypicalSqlPageNotebook {
   private title: string;
   private logoImage: string;


### PR DESCRIPTION
This PR refactors the version retrieval process by removing the Deno code previously used to fetch the Surveilr version using the surveilr --version command. The approach has been updated to use an SQL query to retrieve the version directly from the ur_ingest_session table in the RSSD database.