### PR TITLE
fix: change order of fucnction call

### DIFF
--- a/lib/std/package.sql.ts
+++ b/lib/std/package.sql.ts
@@ -11,8 +11,8 @@ import * as spn from "./notebook/sqlpage.ts";
 export async function SQL() {
   return await spn.TypicalSqlPageNotebook.SQL(
     new sh.ShellSqlPages(),
-    new ur.UniformResourceSqlPages(),
     new c.ConsoleSqlPages(),
+    new ur.UniformResourceSqlPages(),
     new orch.OrchestrationSqlPages(),
     new docs.DocsSqlPages(),
   );


### PR DESCRIPTION
This PR updates the SQL function to adjust the order of module initialization for the TypicalSqlPageNotebook.SQL method. 