### PR TITLE
update: modify the participant and study identifiers #29

### DIFF
--- a/lib/service/diabetes-research-hub/study-specific-stateless/ctr-anderson-stateless.sql
+++ b/lib/service/diabetes-research-hub/study-specific-stateless/ctr-anderson-stateless.sql
@@ -2473,13 +2473,23 @@ ORDER BY
 
 DROP TABLE IF EXISTS participant;
 
-CREATE TABLE
-    IF NOT EXISTS participant AS
-SELECT
-(SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
-    *
-FROM
-    drh_participant;
+CREATE TABLE IF NOT EXISTS participant AS
+SELECT 
+    (SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
+    study_id AS study_display_id,  
+    participant_id AS participant_display_id,  
+    site_id,  
+    diagnosis_icd,  
+    med_rxnorm,  
+    treatment_modality,  
+    gender,  
+    race_ethnicity,  
+    age,  
+    bmi,  
+    baseline_hba1c,  
+    diabetes_type,  
+    study_arm
+FROM drh_participant;
 
     
 DROP TABLE IF EXISTS raw_cgm_lst_cached;

--- a/lib/service/diabetes-research-hub/study-specific-stateless/detrended-stateless.sql
+++ b/lib/service/diabetes-research-hub/study-specific-stateless/detrended-stateless.sql
@@ -2193,13 +2193,23 @@ ORDER BY
 
 DROP TABLE IF EXISTS participant;
 
-CREATE TABLE
-    IF NOT EXISTS participant AS
-SELECT
-(SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
-    *
-FROM
-    drh_participant;
+CREATE TABLE IF NOT EXISTS participant AS
+SELECT 
+    (SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
+    study_id AS study_display_id,  
+    participant_id AS participant_display_id,  
+    site_id,  
+    diagnosis_icd,  
+    med_rxnorm,  
+    treatment_modality,  
+    gender,  
+    race_ethnicity,  
+    age,  
+    bmi,  
+    baseline_hba1c,  
+    diabetes_type,  
+    study_arm
+FROM drh_participant;
 
 
 

--- a/lib/service/diabetes-research-hub/study-specific-stateless/generate-cgm-combined-sql.ts
+++ b/lib/service/diabetes-research-hub/study-specific-stateless/generate-cgm-combined-sql.ts
@@ -593,7 +593,7 @@ export function saveCTRJsonCgm(dbFilePath: string): string {
 
   db.exec(`CREATE TABLE IF NOT EXISTS file_meta_ingest_data (
     db_file_id TEXT NOT NULL,
-    participant_sid TEXT NOT NULL,
+    participant_display_id TEXT NOT NULL,
     file_meta_data TEXT NULL,
     cgm_data TEXT
   );`);
@@ -639,7 +639,7 @@ export function saveCTRJsonCgm(dbFilePath: string): string {
     );
 
     db.prepare(
-      `INSERT INTO file_meta_ingest_data(db_file_id, participant_sid, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`,
+      `INSERT INTO file_meta_ingest_data(db_file_id, participant_display_id, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`,
     ).run(db_file_id, row.patient_id, jsonStringCgm, jsonStringMeta);
   }
 
@@ -667,7 +667,7 @@ export function saveDFAJsonCgm(dbFilePath: string): string {
 
   db.exec(`CREATE TABLE IF NOT EXISTS file_meta_ingest_data (
     db_file_id TEXT NOT NULL,
-    participant_sid TEXT NOT NULL,
+    participant_display_id TEXT NOT NULL,
     file_meta_data TEXT NULL,
     cgm_data TEXT
   );`);
@@ -714,7 +714,7 @@ export function saveDFAJsonCgm(dbFilePath: string): string {
     const jsonStringCgm = isNonCommaseparated ? JSON.stringify(jsonStringObs) : JSON.stringify(rows_obs);
 
     db.prepare(
-      `INSERT INTO file_meta_ingest_data(db_file_id, participant_sid, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`,
+      `INSERT INTO file_meta_ingest_data(db_file_id, participant_display_id, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`,
     ).run(db_file_id, row.patient_id, jsonStringCgm, jsonStringMeta);
   }
 

--- a/lib/service/diabetes-research-hub/study-specific-stateless/ieogc-ingest-data-sql.ts
+++ b/lib/service/diabetes-research-hub/study-specific-stateless/ieogc-ingest-data-sql.ts
@@ -68,7 +68,7 @@ export function processIEOGCgm(dbFilePath: string): string {
 
   db.exec(`CREATE TABLE IF NOT EXISTS file_meta_ingest_data (
     db_file_id TEXT NOT NULL,
-    participant_sid TEXT NOT NULL,
+    participant_display_id TEXT NOT NULL,
     file_meta_data TEXT NULL,
     cgm_data TEXT
   );`);
@@ -101,7 +101,7 @@ export function processIEOGCgm(dbFilePath: string): string {
     const jsonStringCgm = fetchCgmData(db, viewName, row.patient_id);
 
     db.prepare(
-      `INSERT INTO file_meta_ingest_data(db_file_id, participant_sid, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`
+      `INSERT INTO file_meta_ingest_data(db_file_id, participant_display_id, cgm_data, file_meta_data) VALUES (?, ?, ?, ?);`
     ).run(db_file_id, row.patient_id, jsonStringCgm, jsonStringMeta);
   }
 

--- a/lib/service/diabetes-research-hub/study-specific-stateless/ieogc-stateless.sql
+++ b/lib/service/diabetes-research-hub/study-specific-stateless/ieogc-stateless.sql
@@ -2412,13 +2412,23 @@ ORDER BY
 
 DROP TABLE IF EXISTS participant;
 
-CREATE TABLE
-    IF NOT EXISTS participant AS
-SELECT
-(SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
-    *
-FROM
-    drh_participant;
+CREATE TABLE IF NOT EXISTS participant AS
+SELECT 
+    (SELECT db_file_id FROM file_meta_ingest_data LIMIT 1) AS db_file_id,  
+    study_id AS study_display_id,  
+    participant_id AS participant_display_id,  
+    site_id,  
+    diagnosis_icd,  
+    med_rxnorm,  
+    treatment_modality,  
+    gender,  
+    race_ethnicity,  
+    age,  
+    bmi,  
+    baseline_hba1c,  
+    diabetes_type,  
+    study_arm
+FROM drh_participant;
 
 
 DROP TABLE IF EXISTS raw_cgm_lst_cached;


### PR DESCRIPTION



- In **IEOGC**, **DFA**, and **CTR3** participant listings, update the study and participant identifiers when retrieving data from the `drh_participant` view.  
- Modify `file_meta_ingest_data` by changing `participant_sid` to `participant_display_id` for consistency.  

This ensures standardized participant identification across different datasets and aligns with the `drh_participant` view structure.