### PR TITLE
feat: add views and SQL Page UI for system-related tables #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -198,22 +198,32 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         $tab = 'Expectation'    as active;
 
         select 'table' as component,
-        'assets' AS markdown,
+        TRUE    as freeze_headers,
         "All Processes" AS markdown,
-        "Available Disk Space (Linux and Macos)" AS markdown;
+        "Available Disk Space (Linux and Macos)" AS markdown,
+        'Full disk encryption enabled (Linux)' AS markdown,
+        "Installed Linux software" AS markdown,
+        "Listening Ports" AS markdown,
+        "Network Interfaces (Linux and Macos)" AS markdown,
+        "OS Version (Linux and Macos)" AS markdown,
+        "SSH keys encrypted" AS markdown,
+        "Server Uptime" AS markdown,
+        "System Information" AS markdown,
+        "Users" AS markdown;
 
         select 
-        '[' || name || '](' || ${this.absoluteURL("/fleetfolio/asset_detail.sql?link=")} || name || ')' as 'assets',
+        name as 'Asset',
         '[' || (SELECT count FROM system_detail_group WHERE name="All Processes" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/all_process.sql?host_identifier=")} || name || ')' as 'All Processes',
         '[' || (SELECT count FROM system_detail_group WHERE name="Available Disk Space (Linux and Macos)" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_available_disk.sql?host_identifier=")} || name || ')' as 'Available Disk Space (Linux and Macos)',
-        (SELECT count FROM system_detail_group WHERE name="Installed Linux software" AND hostIdentifier=active_asset_list.name) AS "Installed Linux software",
-        (SELECT count FROM system_detail_group WHERE name="Listening Ports" AND hostIdentifier=active_asset_list.name) AS "Listening Ports",
-        (SELECT count FROM system_detail_group WHERE name="Network Interfaces (Linux and Macos)" AND hostIdentifier=active_asset_list.name) AS "Network Interfaces (Linux and Macos)",
-        (SELECT count FROM system_detail_group WHERE name="OS Version (Linux and Macos)" AND hostIdentifier=active_asset_list.name) AS "OS Version (Linux and Macos)",
-        (SELECT count FROM system_detail_group WHERE name="SSH keys encrypted" AND hostIdentifier=active_asset_list.name) AS "SSH keys encrypted",
-        (SELECT count FROM system_detail_group WHERE name="Server Uptime" AND hostIdentifier=active_asset_list.name) AS "Server Uptime",
-        (SELECT count FROM system_detail_group WHERE name="System Information" AND hostIdentifier=active_asset_list.name) AS "System Information",
-        (SELECT count FROM system_detail_group WHERE name="Users" AND hostIdentifier=active_asset_list.name) AS "Users"
+        '[' || (SELECT count FROM system_detail_group WHERE name="Full disk encryption enabled (Linux)" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_full_disk_encryption_linux.sql?host_identifier=")} || name || ')' as 'Full disk encryption enabled (Linux)',
+        '[' || (SELECT count FROM system_detail_group WHERE name="Installed Linux software" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_installed_software_linux.sql?host_identifier=")} || name || ')' as 'Installed Linux software',
+        '[' || (SELECT count FROM system_detail_group WHERE name="Listening Ports" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_listening_ports.sql?host_identifier=")} || name || ')' as 'Listening Ports',
+        '[' || (SELECT count FROM system_detail_group WHERE name="Network Interfaces (Linux and Macos)" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_linux_macos_network_interface.sql?host_identifier=")} || name || ')' as 'Network Interfaces (Linux and Macos)',
+        '[' || (SELECT count FROM system_detail_group WHERE name="OS Version (Linux and Macos)" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_os_version.sql?host_identifier=")} || name || ')' as 'OS Version (Linux and Macos)',
+        '[' || (SELECT count FROM system_detail_group WHERE name="SSH keys encrypted" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_ssh_keys_encrypted.sql?host_identifier=")} || name || ')' as 'SSH keys encrypted',
+        '[' || (SELECT count FROM system_detail_group WHERE name="Server Uptime" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_server_uptime.sql?host_identifier=")} || name || ')' as 'Server Uptime',
+        '[' || (SELECT count FROM system_detail_group WHERE name="System Information" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_information.sql?host_identifier=")} || name || ')' as 'System Information',
+        '[' || (SELECT count FROM system_detail_group WHERE name="Users" AND hostIdentifier=active_asset_list.name) || '](' || ${this.absoluteURL("/fleetfolio/system_user.sql?host_identifier=")} || name || ')' as 'Users'
         FROM active_asset_list WHERE boundary_id=$boundary_id::TEXT AND $tab = 'Discovered';
         
     select 
@@ -392,7 +402,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
     });
     return this.SQL`
 
-           --- Display breadcrumb
+    --- Display breadcrumb
      SELECT
         'breadcrumb' AS component;
       SELECT
@@ -423,8 +433,6 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         ${this.absoluteURL("/fleetfolio/all_process.sql?host_identifier=")} || $host_identifier  AS link
       FROM ${viewName} LIMIT 1;
         
-  
-
        --- Dsply Page Title
       SELECT
        'title' as component,
@@ -434,37 +442,27 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       ${pagination.init()}
       select 
           'table'           as component,
-          TRUE              as sort;
+          TRUE    as freeze_headers,
+          TRUE              as sort,
+          TRUE    as striped_rows,
+          TRUE    as search;
       SELECT 
         name as process,
         host_identifier,
-        cgroup_path,
-        cmdline,
-        cwd,
+       
         disk_bytes_read,
         disk_bytes_written,
-        egid,
-        euid,
-        gid,
         system_name,
-        nice,
-        on_disk,
-        parent,
         path,
-        pgroup,
-        pid,
         resident_size,
-        root,
-        sgid,
         start_time,
         state,
-        suid,
         system_time,
         threads,
         total_size,
-        uid,
-        user_time,
-        wired_size,
+        cgroup_path,
+        cmdline,
+        cwd,
         updated_at FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
       OFFSET $offset;
       ${pagination.renderSimpleMarkdown("host_identifier")};`;
@@ -529,6 +527,592 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
       OFFSET $offset;
       ${pagination.renderSimpleMarkdown("host_identifier", "process")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_full_disk_encryption_linux.sql"() {
+    const viewName = `system_full_disk_encryption_linux`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_full_disk_encryption_linux.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        numerics,
+        policy_result,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_installed_software_linux.sql"() {
+    const viewName = `system_installed_software_linux`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_installed_software_linux.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        numerics,
+        software_name,
+        software_source,
+        software_type,
+        software_version,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_listening_ports.sql"() {
+    const viewName = `system_listening_ports`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_listening_ports.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        address,
+        family,
+        fd,
+        net_namespace,
+        path,
+        pid,
+        port,
+        protocol,
+        socket,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_linux_macos_network_interface.sql"() {
+    const viewName = `system_linux_macos_network_interface`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_linux_macos_network_interface.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        ip_address,
+        mac,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_os_version.sql"() {
+    const viewName = `system_os_version`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_os_version.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        os_name as "os name",
+        platform,
+        os_version as "os version",
+        kernel_version as "kernel version",
+        arch,
+        build,
+        extra,
+        major,
+        minor,
+        patch,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_ssh_keys_encrypted.sql"() {
+    const viewName = `system_ssh_keys_encrypted`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_ssh_keys_encrypted.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        policy_result,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_server_uptime.sql"() {
+    const viewName = `system_server_uptime`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+           --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_server_uptime.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        days,
+        hours,
+        minutes,
+        seconds,
+        total_seconds,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_information.sql"() {
+    const viewName = `system_information`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+    --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_information.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        board_model,
+        board_serial,
+        board_vendor,
+        board_version,
+        computer_name,
+        cpu_brand,
+        cpu_logical_cores,
+        cpu_microcode,
+        cpu_physical_cores,
+        cpu_sockets,
+        cpu_subtype,
+        cpu_type,
+        hardware_model,
+        hardware_serial,
+        hardware_vendor,
+        hardware_version,
+        hostname,
+        local_hostname,
+        physical_memory,
+        uuid,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "fleetfolio/system_user.sql"() {
+    const viewName = `system_user`;
+    const pagination = this.pagination({
+      tableOrViewName: viewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+    return this.SQL`
+
+    --- Display breadcrumb
+     SELECT
+        'breadcrumb' AS component;
+      SELECT
+        'Home' AS title,
+        ${this.absoluteURL("/")}    AS link;
+      SELECT
+        'FleetFolio' AS title,
+        ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
+      SELECT
+        'Parent Boundary' AS title,
+        ${this.absoluteURL("/fleetfolio/parent_boundary.sql")} AS link; 
+
+      SELECT parent.name AS title,
+        ${this.absoluteURL("/fleetfolio/boundary.sql?boundary_id=")} || parent.boundary_id AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary child ON child.boundary_id=assl.boundary_id
+      INNER JOIN all_boundary parent ON parent.boundary_id=child.parent_boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+
+      SELECT 
+      ab.name AS title,
+      ${this.absoluteURL("/fleetfolio/inner_boundary.sql?tab=Discovered&boundary_id=")} || ab.boundary_id  AS link
+      FROM active_asset_list assl
+      INNER JOIN all_boundary ab ON ab.boundary_id=assl.boundary_id
+      WHERE assl.name=$host_identifier::TEXT;
+      SELECT
+        name AS title,
+        ${this.absoluteURL("/fleetfolio/system_user.sql?host_identifier=")} || $host_identifier  AS link
+        FROM ${viewName} LIMIT 1;
+
+       --- Dsply Page Title
+      SELECT
+       'title' as component,
+        name as contents FROM ${viewName} LIMIT 1;
+
+       ${pagination.init()}
+      select 
+          'table'           as component,
+          TRUE              as sort,
+          TRUE    as freeze_headers;
+      SELECT 
+        name as process,
+        host_identifier as "host identifier",
+        user_name as "user name",
+        directory,
+        description,
+        gid,
+        gid_signed,
+        shell,
+        uid,
+        uid_signed,
+        uuid,
+        updated_at
+        FROM ${viewName} WHERE host_identifier = $host_identifier::TEXT LIMIT $limit
+      OFFSET $offset;
+      ${pagination.renderSimpleMarkdown("host_identifier")};`;
   }
 }
 

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -69,49 +69,220 @@ GROUP BY name, hostIdentifier;
 DROP VIEW IF EXISTS system_detail_all_processes;
 CREATE VIEW system_detail_all_processes AS
 SELECT 
-    uniform_resource_id,
-    json_extract(content, '$.name') AS name,
-    json_extract(content, '$.hostIdentifier') AS host_identifier,
-    json_extract(content, '$.columns.cgroup_path') AS cgroup_path,
-    json_extract(content, '$.columns.cmdline') AS cmdline,
-    json_extract(content, '$.columns.cwd') AS cwd,
-    json_extract(content, '$.columns.disk_bytes_read') AS disk_bytes_read,
-    json_extract(content, '$.columns.disk_bytes_written') AS disk_bytes_written,
-    json_extract(content, '$.columns.egid') AS egid,
-    json_extract(content, '$.columns.euid') AS euid,
-    json_extract(content, '$.columns.gid') AS gid,
-    json_extract(content, '$.columns.name') AS system_name,
-    json_extract(content, '$.columns.nice') AS nice,
-    json_extract(content, '$.columns.on_disk') AS on_disk,
-    json_extract(content, '$.columns.parent') AS parent,
-    json_extract(content, '$.columns.path') AS path,
-    json_extract(content, '$.columns.pgroup') AS pgroup,
-    json_extract(content, '$.columns.pid') AS pid,
-    json_extract(content, '$.columns.resident_size') AS resident_size,
-    json_extract(content, '$.columns.root') AS root,
-    json_extract(content, '$.columns.sgid') AS sgid,
-    json_extract(content, '$.columns.start_time') AS start_time,
-    json_extract(content, '$.columns.state') AS state,
-    json_extract(content, '$.columns.suid') AS suid,
-    json_extract(content, '$.columns.system_time') AS system_time,
-    json_extract(content, '$.columns.threads') AS threads,
-    json_extract(content, '$.columns.total_size') AS total_size,
-    json_extract(content, '$.columns.uid') AS uid,
-    json_extract(content, '$.columns.user_time') AS user_time,
-    json_extract(content, '$.columns.wired_size') AS wired_size,
-    updated_at
-FROM uniform_resource 
-WHERE name = 'All Processes';
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier,
+    json_extract(u.content, '$.columns.cgroup_path') AS cgroup_path,
+    json_extract(u.content, '$.columns.cmdline') AS cmdline,
+    json_extract(u.content, '$.columns.cwd') AS cwd,
+    json_extract(u.content, '$.columns.disk_bytes_read') AS disk_bytes_read,
+    json_extract(u.content, '$.columns.disk_bytes_written') AS disk_bytes_written,
+    json_extract(u.content, '$.columns.egid') AS egid,
+    json_extract(u.content, '$.columns.euid') AS euid,
+    json_extract(u.content, '$.columns.gid') AS gid,
+    json_extract(u.content, '$.columns.name') AS system_name,
+    json_extract(u.content, '$.columns.nice') AS nice,
+    json_extract(u.content, '$.columns.on_disk') AS on_disk,
+    json_extract(u.content, '$.columns.parent') AS parent,
+    json_extract(u.content, '$.columns.path') AS path,
+    json_extract(u.content, '$.columns.pgroup') AS pgroup,
+    json_extract(u.content, '$.columns.pid') AS pid,
+    json_extract(u.content, '$.columns.resident_size') AS resident_size,
+    json_extract(u.content, '$.columns.root') AS root,
+    json_extract(u.content, '$.columns.sgid') AS sgid,
+    json_extract(u.content, '$.columns.start_time') AS start_time,
+    json_extract(u.content, '$.columns.state') AS state,
+    json_extract(u.content, '$.columns.suid') AS suid,
+    json_extract(u.content, '$.columns.system_time') AS system_time,
+    json_extract(u.content, '$.columns.threads') AS threads,
+    json_extract(u.content, '$.columns.total_size') AS total_size,
+    json_extract(u.content, '$.columns.uid') AS uid,
+    json_extract(u.content, '$.columns.user_time') AS user_time,
+    json_extract(u.content, '$.columns.wired_size') AS wired_size,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'All Processes' AND ue.graph_name='osquery-ms';
 
 DROP VIEW IF EXISTS system_available_disk;
 CREATE VIEW system_available_disk AS
 SELECT 
-    uniform_resource_id,
-    json_extract(content, '$.name') AS name,
-    json_extract(content, '$.hostIdentifier') AS host_identifier,
-    json_extract(content, '$.columns.gigs_disk_space_available') AS gigs_disk_space_available,
-    json_extract(content, '$.columns.gigs_total_disk_space') AS gigs_total_disk_space,
-    json_extract(content, '$.columns.percent_disk_space_available') AS percent_disk_space_available,
-    updated_at
-FROM uniform_resource 
-WHERE name = 'Available Disk Space (Linux and Macos)';
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier,
+    json_extract(u.content, '$.columns.gigs_disk_space_available') AS gigs_disk_space_available,
+    json_extract(u.content, '$.columns.gigs_total_disk_space') AS gigs_total_disk_space,
+    json_extract(u.content, '$.columns.percent_disk_space_available') AS percent_disk_space_available,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Available Disk Space (Linux and Macos)' AND ue.graph_name='osquery-ms'; 
+
+DROP VIEW IF EXISTS system_full_disk_encryption_linux;
+CREATE VIEW system_full_disk_encryption_linux AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.policy_result') AS policy_result,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Full disk encryption enabled (Linux)' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_installed_software_linux;
+CREATE VIEW system_installed_software_linux AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.name') AS software_name,
+    json_extract(u.content, '$.columns.source') AS software_source,
+    json_extract(u.content, '$.columns.type') AS software_type,
+    json_extract(u.content, '$.columns.version') AS software_version,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Installed Linux software' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_listening_ports;
+CREATE VIEW system_listening_ports AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.address') AS address,
+    json_extract(u.content, '$.columns.family') AS family,
+    json_extract(u.content, '$.columns.fd') AS fd,
+    json_extract(u.content, '$.columns.net_namespace') AS net_namespace,
+    json_extract(u.content, '$.columns.path') AS path,
+    json_extract(u.content, '$.columns.pid') AS pid,
+    json_extract(u.content, '$.columns.port') AS port,
+    json_extract(u.content, '$.columns.protocol') AS protocol,
+    json_extract(u.content, '$.columns.socket') AS socket,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Listening Ports' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_linux_macos_network_interface;
+CREATE VIEW system_linux_macos_network_interface AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.address') AS ip_address,
+    json_extract(u.content, '$.columns.mac') AS mac,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Network Interfaces (Linux and Macos)' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_os_version;
+CREATE VIEW system_os_version AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.arch') AS arch,
+    json_extract(u.content, '$.columns.build') AS build,
+    json_extract(u.content, '$.columns.extra') AS extra,
+    json_extract(u.content, '$.columns.kernel_version') AS kernel_version,
+    json_extract(u.content, '$.columns.major') AS major,
+    json_extract(u.content, '$.columns.minor') AS minor,
+    json_extract(u.content, '$.columns.name') AS os_name,
+    json_extract(u.content, '$.columns.patch') AS patch,
+    json_extract(u.content, '$.columns.platform') AS platform,
+    json_extract(u.content, '$.columns.version') AS os_version,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'OS Version (Linux and Macos)' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_ssh_keys_encrypted;
+CREATE VIEW system_ssh_keys_encrypted AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.policy_result') AS policy_result,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'SSH keys encrypted' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_server_uptime;
+CREATE VIEW system_server_uptime AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.days') AS days,
+    json_extract(u.content, '$.columns.hours') AS hours,
+    json_extract(u.content, '$.columns.minutes') AS minutes,
+    json_extract(u.content, '$.columns.seconds') AS seconds,
+    json_extract(u.content, '$.columns.total_seconds') AS total_seconds,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Server Uptime' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_information;
+CREATE VIEW system_information AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.board_model') AS board_model,
+    json_extract(u.content, '$.columns.board_serial') AS board_serial,
+    json_extract(u.content, '$.columns.board_vendor') AS board_vendor,
+    json_extract(u.content, '$.columns.board_version') AS board_version,
+    json_extract(u.content, '$.columns.computer_name') AS computer_name,
+    json_extract(u.content, '$.columns.cpu_brand') AS cpu_brand,
+    json_extract(u.content, '$.columns.cpu_logical_cores') AS cpu_logical_cores,
+    json_extract(u.content, '$.columns.cpu_microcode') AS cpu_microcode,
+    json_extract(u.content, '$.columns.cpu_physical_cores') AS cpu_physical_cores,
+    json_extract(u.content, '$.columns.cpu_sockets') AS cpu_sockets,
+    json_extract(u.content, '$.columns.cpu_subtype') AS cpu_subtype,
+    json_extract(u.content, '$.columns.cpu_type') AS cpu_type,
+    json_extract(u.content, '$.columns.hardware_model') AS hardware_model,
+    json_extract(u.content, '$.columns.hardware_serial') AS hardware_serial,
+    json_extract(u.content, '$.columns.hardware_vendor') AS hardware_vendor,
+    json_extract(u.content, '$.columns.hardware_version') AS hardware_version,
+    json_extract(u.content, '$.columns.hostname') AS hostname,
+    json_extract(u.content, '$.columns.local_hostname') AS local_hostname,
+    json_extract(u.content, '$.columns.physical_memory') AS physical_memory,
+    json_extract(u.content, '$.columns.uuid') AS uuid,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'System Information' AND ue.graph_name='osquery-ms';
+
+DROP VIEW IF EXISTS system_user;
+CREATE VIEW system_user AS
+SELECT 
+    u.uniform_resource_id,
+    json_extract(u.content, '$.name') AS name,
+    json_extract(u.content, '$.hostIdentifier') AS host_identifier, 
+    json_extract(u.content, '$.numerics') AS numerics,
+    json_extract(u.content, '$.columns.username') AS user_name,
+    json_extract(u.content, '$.columns.directory') AS directory,
+    json_extract(u.content, '$.columns.description') AS description,
+    json_extract(u.content, '$.columns.gid') AS gid,
+    json_extract(u.content, '$.columns.gid_signed') AS gid_signed,
+    json_extract(u.content, '$.columns.shell') AS shell,
+    json_extract(u.content, '$.columns.uid') AS uid,
+    json_extract(u.content, '$.columns.uid_signed') AS uid_signed,
+    json_extract(u.content, '$.columns.uuid') AS uuid,
+    u.updated_at
+FROM uniform_resource u
+INNER JOIN uniform_resource_edge ue ON ue.uniform_resource_id=u.uniform_resource_id
+WHERE name = 'Users' AND ue.graph_name='osquery-ms';


### PR DESCRIPTION
Created views and SQL Page UI for the following system-related tables:

1. **system_user** – Stores information about system users.
2. **system_information** – Contains general system details such as hostname and architecture.
3. **system_server_uptime** – Tracks system uptime.
4. **system_ssh_keys_encrypted** – Manages SSH key encryption status.
5. **system_os_version** – Records OS version details.