### PR TITLE
refactor : Update OSQuery Process Query - Modify pid Retrieval #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -167,21 +167,21 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
     description: "Osquery SystemInfo",
   }, ["linux"])
   "Osquery SystemInfo"() {
-    return `SELECT *  from system_info`;
+    return `SELECT *  from system_info;`;
   }
 
   @osQueryMsCell({
     description: "Osquery All Processes",
   }, ["linux"])
   "Osquery All Processes"() {
-    return `select pid,name, path from processes`;
+    return `select name, path from processes;`;
   }
 
   @osQueryMsCell({
     description: "Osquery Authentication Log",
   }, ["linux"])
   "Osquery Authentication Log"() {
-    return `SELECT username, tty, time, status, message FROM authentications`;
+    return `SELECT username, tty, time, status, message FROM authentications;`;
   }
 }
 


### PR DESCRIPTION
This PR updates the OSQuery query for retrieving process details by modifying how the pid (Process ID) is handled.