### PR TITLE
feat : add docker container port query #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -122,6 +122,14 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
   }
 
   @osQueryMsCell({
+    description: "Docker Container Ports.",
+  }, ["macos", "linux"])
+  "Docker Container Ports"() {
+    return `select id,type,port,host_ip,host_port from docker_container_ports;`;
+  }
+
+
+  @osQueryMsCell({
     description: "Osquery Mfa Enabled.",
   }, ["linux"])
   "Osquery Mfa Enabled"() {


### PR DESCRIPTION
This PR adds an osquery query to retrieve Docker container port mappings. The query fetches private and public ports, along with container names, to provide better visibility into running container networking configurations.