### PR TITLE
feat : add user id process id  in all container process query #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -179,10 +179,10 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
   }
 
   @osQueryMsCell({
-    description: "Osquery All Processes",
+    description: "Osquery All Container Processes",
   }, ["linux"])
-  "Osquery All Processes"() {
-    return `SELECT name, path, uid from processes;`;
+  "Osquery All Container Processes"() {
+    return `SELECT name, path, uid, pid, uid from processes;`;
   }
 
   @osQueryMsCell({


### PR DESCRIPTION
This PR enhances the container process visibility by including both user ID (uid) and process ID (pid) in the container process query. This allows improved user-level tracking of processes running within Docker containers, which is useful for auditing and security.