### PR TITLE
feat: add aws daily and monthly cost detail #355

### DIFF
--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -428,3 +428,18 @@ SELECT
 FROM uniform_resource,
      json_each(content,'$.rows')
 WHERE uri = 'SteampipeAwsCostByServiceDaily';
+
+-- SteampipeAwsCostByServiceMonthly
+DROP TABLE IF EXISTS ur_transform_list_aws_monthly_cost_by_service;
+CREATE TABLE ur_transform_list_aws_monthly_cost_by_service AS
+SELECT 
+  json_extract(value, '$.period_start') AS period_start, 
+  json_extract(value, '$.period_end') AS period_end, 
+  json_extract(value, '$.account_id') AS account_id,
+  json_extract(value, '$.service') AS service, 
+  json_extract(value, '$.region') AS region,
+  json_extract(value, '$.amortized_cost_amount') AS amortized_cost_amount,
+  json_extract(value, '$.usage_quantity_amount') AS usage_quantity_amount
+FROM uniform_resource,
+     json_each(content,'$.rows')
+WHERE uri = 'SteampipeAwsCostByServiceMonthly';

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -296,3 +296,17 @@ acd.amortized_cost_amount,
 acc.title as account
 FROM ur_transform_list_aws_daily_cost_by_service AS acd
 INNER JOIN ur_transform_aws_account_info AS acc ON acd.account_id = acc.account_id ORDER BY acd.period_start DESC;
+
+DROP VIEW IF EXISTS list_aws_monthly_service_cost;
+CREATE VIEW list_aws_monthly_service_cost AS
+SELECT 
+acd.period_start,
+acd.period_end,
+acd.service,
+acd.region,
+acd.amortized_cost_amount,
+acd.usage_quantity_amount,
+acd.amortized_cost_amount,
+acc.title as account
+FROM ur_transform_list_aws_monthly_cost_by_service AS acd
+INNER JOIN ur_transform_aws_account_info AS acc ON acd.account_id = acc.account_id ORDER BY acd.period_start DESC;

--- a/lib/std/notebook/sqlpage.ts
+++ b/lib/std/notebook/sqlpage.ts
@@ -32,14 +32,14 @@ export interface SqlPagesFileRecord {
 export type PathShellConfig = {
   readonly path: string;
   readonly shellStmts:
-    | "do-not-include"
-    | ((spfr: SqlPagesFileRecord) => string | string[]);
+  | "do-not-include"
+  | ((spfr: SqlPagesFileRecord) => string | string[]);
   readonly breadcrumbsFromNavStmts:
-    | "no"
-    | ((spfr: SqlPagesFileRecord) => string | string[]);
+  | "no"
+  | ((spfr: SqlPagesFileRecord) => string | string[]);
   readonly pageTitleFromNavStmts:
-    | "no"
-    | ((spfr: SqlPagesFileRecord) => string | string[]);
+  | "no"
+  | ((spfr: SqlPagesFileRecord) => string | string[]);
 };
 
 /**
@@ -389,17 +389,15 @@ export class TypicalSqlPageNotebook
       init: () => {
         const countSQL = config.countSQL
           ? config.countSQL
-          : this.SQL`SELECT COUNT(*) FROM ${config.tableOrViewName} ${
-            config.whereSQL && config.whereSQL.length > 0 ? config.whereSQL : ``
-          }`;
+          : this.SQL`SELECT COUNT(*) FROM ${config.tableOrViewName} ${config.whereSQL && config.whereSQL.length > 0 ? config.whereSQL : ``
+            }`;
 
         return this.SQL`
           SET ${n("total_rows")} = (${countSQL.SQL(this.emitCtx)});
           SET ${n("limit")} = COALESCE(${$("limit")}, 50);
           SET ${n("offset")} = COALESCE(${$("offset")}, 0);
-          SET ${n("total_pages")} = (${$("total_rows")} + ${
-          $("limit")
-        } - 1) / ${$("limit")};
+          SET ${n("total_pages")} = (${$("total_rows")} + ${$("limit")
+          } - 1) / ${$("limit")};
           SET ${n("current_page")} = (${$("offset")} / ${$("limit")}) + 1;`;
       },
 
@@ -421,23 +419,16 @@ export class TypicalSqlPageNotebook
         );
         return this.SQL`
           SELECT 'text' AS component,
-              (SELECT CASE WHEN ${
-          $("current_page")
-        } > 1 THEN '[Previous](?limit=' || ${$("limit")} || '&offset=' || (${
-          $("offset")
-        } - ${$("limit")}) ||  ${
-          filteredParams.map((qp) => `'&${n(qp)}=' || ${$(qp)} ||`)
-        }   ')' ELSE '' END) || ' ' ||
-              '(Page ' || ${$("current_page")} || ' of ' || ${
-          $("total_pages")
-        } || ") " ||
-              (SELECT CASE WHEN ${$("current_page")} < ${
-          $("total_pages")
-        } THEN '[Next](?limit=' || ${$("limit")} || '&offset=' || (${
-          $("offset")
-        } + ${$("limit")}) ||   ${
-          filteredParams.map((qp) => `'&${n(qp)}=' || ${$(qp)} ||`)
-        }  ')' ELSE '' END)
+              (SELECT CASE WHEN ${$("current_page")
+          } > 1 THEN '[Previous](?limit=' || ${$("limit")} || '&offset=' || (${$("offset")
+          } - ${$("limit")}) ||  ${filteredParams.map((qp) => `'&${n(qp)}=' || replace(${$(qp)}, ' ', '%20') ||`)
+          }   ')' ELSE '' END) || ' ' ||
+              '(Page ' || ${$("current_page")} || ' of ' || ${$("total_pages")
+          } || ") " ||
+              (SELECT CASE WHEN ${$("current_page")} < ${$("total_pages")
+          } THEN '[Next](?limit=' || ${$("limit")} || '&offset=' || (${$("offset")
+          } + ${$("limit")}) ||   ${filteredParams.map((qp) => `'&${n(qp)}=' || replace(${$(qp)}, ' ', '%20') ||`)
+          }  ')' ELSE '' END)
               AS contents_md 
           ${whereTabvalue ? ` WHERE ${whereTabvalue}` : ""};`;
       },
@@ -449,8 +440,8 @@ export class TypicalSqlPageNotebook
       typeof text === "number"
         ? text
         : text
-        ? this.emitCtx.sqlTextEmitOptions.quotedLiteral(text)[1]
-        : "NULL";
+          ? this.emitCtx.sqlTextEmitOptions.quotedLiteral(text)[1]
+          : "NULL";
     // deno-fmt-ignore
     return this.SQL`
       INSERT INTO sqlpage_aide_navigation (namespace, parent_path, sibling_order, path, url, caption, abbreviated_caption, title, description,elaboration)
@@ -599,9 +590,8 @@ export class TypicalSqlPageNotebook
     return this.SQL`
           SELECT 'title' AS component, (SELECT COALESCE(title, caption)
               FROM sqlpage_aide_navigation
-             WHERE namespace = 'prime' AND path = ${
-      literal(activePPC?.absPath ?? "/")
-    }) as contents;
+             WHERE namespace = 'prime' AND path = ${literal(activePPC?.absPath ?? "/")
+      }) as contents;
     `;
   }
 
@@ -616,11 +606,10 @@ export class TypicalSqlPageNotebook
     const methodName = activePPC?.methodName.replaceAll("'", "''") ?? "??";
     return this.SQL`
         SELECT 'text' AS component,
-       '[View ${methodName}](' || ${
-      this.absoluteURL(
-        `/console/sqlpage-files/sqlpage-file.sql?path=${methodName}`,
-      )
-    } || ')' AS contents_md;       
+       '[View ${methodName}](' || ${this.absoluteURL(
+      `/console/sqlpage-files/sqlpage-file.sql?path=${methodName}`,
+    )
+      } || ')' AS contents_md;       
   `;
   }
 


### PR DESCRIPTION
This PR introduces support for retrieving and displaying AWS daily and monthly cost details. It enhances cost visibility by enabling analysis at multiple time granularities, which is essential for both operational monitoring and long-term budgeting.