### PR TITLE
refactor: replace logo and favicon for compliance explorer #355

### DIFF
--- a/lib/pattern/compliance-explorer/package.sql.ts
+++ b/lib/pattern/compliance-explorer/package.sql.ts
@@ -8,8 +8,8 @@ import {
 } from "../../std/web-ui-content/mod.ts";
 
 const SQE_TITLE = "Compliance Explorer";
-const SQE_LOGO = "scf-icon.png";
-const SQE_FAV_ICON = "scf-favicon.ico";
+const SQE_LOGO = "compliance-explorer.png";
+const SQE_FAV_ICON = "content-assembler.ico";
 
 // custom decorator that makes navigation for this notebook type-safe
 function ceNav(route: Omit<spn.RouteConfig, "path" | "parentPath">) {
@@ -56,9 +56,8 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       '**Health Insurance Portability and Accountability Act (HIPAA)**' || '  \n' ||
       '**Version:** ' || version || '  \n' ||
       '**Published/Last Reviewed Date/Year:** ' || last_reviewed_date || '  \n' ||
-      '[**Detail View**](' || ${
-      this.absoluteURL("/ce/regime/controls.sql?regimeType=US%20HIPAA")
-    }|| ')' AS description_md
+      '[**Detail View**](' || ${this.absoluteURL("/ce/regime/controls.sql?regimeType=US%20HIPAA")
+      }|| ')' AS description_md
     FROM compliance_regime
     WHERE title = 'US HIPAA';
 
@@ -69,9 +68,8 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       '**Standard 800-53 rev4**' || '  \n' ||
       '**Version:** ' || version || '  \n' ||
       '**Published/Last Reviewed Date/Year:** ' || last_reviewed_date || '  \n' ||
-      '[**Detail View**](' || ${
-      this.absoluteURL("/ce/regime/controls.sql?regimeType=NIST")
-    } || ')' AS description_md
+      '[**Detail View**](' || ${this.absoluteURL("/ce/regime/controls.sql?regimeType=NIST")
+      } || ')' AS description_md
     FROM compliance_regime
     WHERE title = 'NIST';`;
   }
@@ -94,9 +92,8 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       TRUE AS sort,
       TRUE AS search,
       "Control Code" AS markdown;
-      SELECT '[' || control_code || ']('|| ${
-      this.absoluteURL("/ce/regime/control/control_detail.sql?id=")
-    } || control_code || '&regimeType='|| replace($regimeType,
+      SELECT '[' || control_code || ']('|| ${this.absoluteURL("/ce/regime/control/control_detail.sql?id=")
+      } || control_code || '&regimeType='|| replace($regimeType,
     " ", "%20")||')' AS "Control Code",
       scf_control AS "Title",
       scf_domain AS "Domain",


### PR DESCRIPTION
This PR updates the visual branding assets for Compliance Explorer by replacing the existing logo and favicon with the new.