### PR TITLE
fix: correct caption casing and rename keys #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -49,15 +49,15 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
   }
 
   @spn.navigationPrimeTopLevel({
-    caption: "FleetFolio",
+    caption: "Fleetfolio",
     description:
-      `FleetFolio is a powerful infrastructure assurance platform built on surveilr that helps organizations achieve continuous compliance, security, and operational reliability. Unlike traditional asset management tools that simply list discovered assets, FleetFolio takes a proactive approach by defining expected infrastructure assets and verifying them against actual assets found using osQuery Management Server (MS).`,
+      `Fleetfolio is a powerful infrastructure assurance platform built on surveilr that helps organizations achieve continuous compliance, security, and operational reliability. Unlike traditional asset management tools that simply list discovered assets, Fleetfolio takes a proactive approach by defining expected infrastructure assets and verifying them against actual assets found using osQuery Management Server (MS).`,
   })
   "fleetfolio/index.sql"() {
     return this.SQL`
     select
         'text'              as component,
-        'FleetFolio is a powerful infrastructure assurance platform built on surveilr that helps organizations achieve continuous compliance, security, and operational reliability. Unlike traditional asset management tools that simply list discovered assets, FleetFolio takes a proactive approach by defining expected infrastructure assets and verifying them against actual assets found using osQuery Management Server (MS).' as contents;
+        'Fleetfolio is a powerful infrastructure assurance platform built on surveilr that helps organizations achieve continuous compliance, security, and operational reliability. Unlike traditional asset management tools that simply list discovered assets, Fleetfolio takes a proactive approach by defining expected infrastructure assets and verifying them against actual assets found using osQuery Management Server (MS).' as contents;
       WITH navigation_cte AS (
           SELECT COALESCE(title, caption) as title, description
             FROM sqlpage_aide_navigation
@@ -75,7 +75,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
   }
 
   @fleetfolioNav({
-    caption: "Boundary",
+    caption: "Boundaries",
     description:
       `The Server (Host) List ingested via osQuery provides real-time visibility into all discovered infrastructure assets.`,
     siblingOrder: 1,
@@ -133,13 +133,33 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
           SELECT
               'title'   as component,
               'Assets ' contents;
-
-             select
+            select
               'text'              as component,
               'Assets refer to a collection of IT resources such as nodes, servers, virtual machines, and other infrastructure components' as contents;
 
+          -- Display dasboard count of physical boundaries
+          SELECT 
+            'card'                     as component,
+            'Physical boundaries' as title,
+            4                     as columns;
+            select 
+                boundary_name  as title,
+                'assets.sql?physical_boundary='||boundary_name as link,
+                host_count as description
+                FROM boundary_asset_count_list;
 
+          
 
+          -- Display dasboard count of logical boundaries
+          SELECT 
+            'card'                     as component,
+            'Logical boundaries' as title,
+            4                     as columns;
+            select 
+                boundary_name  as title,
+                'assets.sql?logical_boundary='||boundary_name as link,
+                host_count as description
+                FROM logical_boundary_asset_count_list;
 
             -- asset list
         SELECT 'table' AS component,
@@ -163,7 +183,13 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         ip_address AS "IP Address",
         last_fetched AS "Last Fetched",
         last_restarted AS "Last Restarted"
-        FROM host_list;
+        FROM host_list 
+        WHERE
+          CASE
+              WHEN $physical_boundary IS NOT NULL THEN boundary LIKE '%'||$physical_boundary||'%'
+              WHEN $logical_boundary IS NOT NULL THEN logical_boundary LIKE '%'||$logical_boundary||'%'
+              ELSE 1 = 1
+          END;
             `;
   }
 
@@ -178,7 +204,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             'Home' AS title,
             ${this.absoluteURL("/")}    AS link;
         SELECT
-            'FleetFolio' AS title,
+            'Fleetfolio' AS title,
             ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
         SELECT 'Boundary' AS title,
             ${this.absoluteURL("/fleetfolio/boundary.sql")} AS link;
@@ -263,7 +289,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             'Home' AS title,
             ${this.absoluteURL("/")}    AS link;
         SELECT
-            'FleetFolio' AS title,
+            'Fleetfolio' AS title,
             ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
         SELECT
             'Boundary' AS title,
@@ -549,7 +575,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -618,7 +644,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -673,7 +699,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -795,7 +821,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -850,7 +876,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -910,7 +936,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -970,7 +996,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -1028,7 +1054,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,
@@ -1107,7 +1133,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'Home' AS title,
         ${this.absoluteURL("/")}    AS link;
       SELECT
-        'FleetFolio' AS title,
+        'Fleetfolio' AS title,
         ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
       SELECT
         'Boundary' AS title,

--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -62,6 +62,21 @@ CREATE TABLE IF NOT EXISTS "asset" (
     FOREIGN KEY("assignment_id") REFERENCES "assignment"("assignment_id")
 );
 
+CREATE TABLE IF NOT EXISTS "asset_boundary" (
+    "asset_boundary_id" TEXT PRIMARY KEY NOT NULL,
+    "asset_id" TEXT NOT NULL,
+    "boundary_id" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    "created_by" TEXT DEFAULT 'UNKNOWN',
+    "updated_at" TIMESTAMPTZ,
+    "updated_by" TEXT,
+    "deleted_at" TIMESTAMPTZ,
+    "deleted_by" TEXT,
+    "activity_log" TEXT,
+    FOREIGN KEY("asset_id") REFERENCES "asset"("asset_id"),
+    FOREIGN KEY("boundary_id") REFERENCES "boundary"("boundary_id")
+);
+
 CREATE TABLE IF NOT EXISTS "asset_type" (
     "asset_type_id" TEXT PRIMARY KEY NOT NULL,
     "code" TEXT /* UNIQUE COLUMN */ NOT NULL,

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -125,6 +125,30 @@ LEFT JOIN surveilr_osquery_ms_node_detail nodeDet ON nodeDet.host_identifier=bou
 LEFT JOIN surveilr_osquery_ms_node_system_info sysinfo ON sysinfo.host_identifier=boundary.host_identifier
 LEFT JOIN expected_asset_list eal ON nodeDet.host_identifier= eal.host;
 
+DROP VIEW IF EXISTS boundary_asset_count_list;
+CREATE VIEW boundary_asset_count_list AS
+SELECT 
+    boundary.boundary AS boundary_name,
+    COUNT(DISTINCT boundary.host_identifier) AS host_count
+FROM surveilr_osquery_ms_node_boundary boundary
+LEFT JOIN surveilr_osquery_ms_node_detail nodeDet 
+    ON nodeDet.host_identifier = boundary.host_identifier
+GROUP BY boundary.boundary
+ORDER BY host_count DESC;
+
+DROP VIEW IF EXISTS logical_boundary_asset_count_list;
+CREATE VIEW logical_boundary_asset_count_list AS
+SELECT 
+    bnt.name AS boundary_name,
+    COUNT(ast_bnt.asset_id) AS host_count
+FROM boundary bnt 
+INNER JOIN asset_boundary ast_bnt ON ast_bnt.boundary_id = bnt.boundary_id
+INNER JOIN asset ON asset.asset_id = ast_bnt.asset_id
+INNER JOIN surveilr_osquery_ms_node_detail node ON node.host_identifier=asset.name
+WHERE bnt.parent_boundary_id IS NOT NULL
+GROUP BY bnt.name
+ORDER BY host_count DESC;;
+
 -- policy list of host 
 DROP VIEW IF EXISTS asset_policy_list;
 CREATE VIEW asset_policy_list AS


### PR DESCRIPTION
This PR addresses minor text corrections and key renaming to improve consistency and accuracy in the codebase.

**Changes Made**
Corrected the casing of the caption from "FleetFolio" to "Fleetfolio".

**Renamed object keys for clarity and consistency:**
asset → assets
boundary → boundries