### PR TITLE
refactor: remove resident_size from container daemon info query to prevent db size growth #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -128,7 +128,6 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
               path,
               pgroup,
               pid,
-              resident_size,
               root,
               sgid,
               strftime('%Y-%m-%d', datetime(start_time, 'unixepoch')) AS start_time,


### PR DESCRIPTION
Removed the resident_size field from the container daemon info query to prevent unnecessary database size growth.