### PR TITLE
feat: add osquery query for IDS PSAD log monitoring #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -273,7 +273,23 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
   "Osquery Authentication Log"() {
     return `SELECT username, tty, time, status, message FROM authentications;`;
   }
+
+  @osQueryMsCell({
+    description: "Osquery IDS Fail2ban Log",
+  }, ["linux"])
+  "Osquery IDS Fail2ban Log"() {
+    return `SELECT name, type , notnull, dflt_value, pk  FROM file WHERE path LIKE '/var/log/fail2ban.log';`;
+  }
+
+  @osQueryMsCell({
+    description: "Osquery IDS PSAD Log",
+  }, ["linux"])
+  "Osquery IDS PSAD Log"() {
+    return `SELECT name, type , notnull, dflt_value, pk  FROM file WHERE path LIKE '/var/log/fail2ban.log';`;
+  }
 }
+
+
 
 export async function SQL() {
   return await cnb.TypicalCodeNotebook.SQL(


### PR DESCRIPTION
This PR adds a new osquery query to monitor IDS PSAD logs. The query targets files under /var/log/psad* and /var/log/iptables.log to help detect and audit intrusion detection system (IDS) activity.