### PR TITLE
feat: added ssl/tls enabled tab to host detail page in fleetfolio #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -280,6 +280,11 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       tableOrViewName: assetServiceViewName,
       whereSQL: "WHERE host_identifier=$host_identifier",
     });
+    const listPorts443ViewName = `list_ports_443`;
+    const listPorts443Pagination = this.pagination({
+      tableOrViewName: listPorts443ViewName,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
     return this.SQL`
       ${this.activePageTitle()}
         --- Display breadcrumb
@@ -430,7 +435,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
 
         select 
         'divider' as component,
-        'System Environment'   as contents;
+        'System Environment'   as contents; 
 
         SELECT 'tab' AS component, TRUE AS center;
         SELECT 'Policies' AS title, '?tab=policies&host_identifier=' || $host_identifier AS link, ($tab = 'policies' OR $tab IS NULL) AS active;
@@ -439,6 +444,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         select 'Containers' as title, '?tab=container&host_identifier=' || $host_identifier AS link, $tab = 'container' as active;
         select 'All Process' as title, '?tab=all_process&host_identifier=' || $host_identifier AS link, $tab = 'all_process' as active;
         select 'Asset Service' as title, '?tab=asset_service&host_identifier=' || $host_identifier AS link, $tab = 'asset_service' as active;
+        select 'SSL/TLS is enabled' as title, '?tab=ssl_tls_is_enabled&host_identifier=' || $host_identifier AS link, $tab = 'ssl_tls_is_enabled' as active;
 
 
 
@@ -478,6 +484,14 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       )
       };
 
+
+      SELECT
+            'html' AS component,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>osquery</strong>
+            </div>' AS html
+          WHERE $tab = 'software';
+
         -- Software table and tab value Start here
        
         ${softwarePagination.init()} 
@@ -495,6 +509,24 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       )
       };
 
+      SELECT
+            'html' AS component,
+            contents,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>' || contents || '</strong>
+            </div>' AS html
+          FROM (
+            SELECT
+              query_uri,
+              CASE
+                WHEN query_uri LIKE '%osquery%' THEN 'osquery'
+                WHEN query_uri LIKE '%Steampipe%' THEN 'Steampipe'
+                ELSE 'Other'
+              END AS contents
+            FROM ${userListViewName}
+            LIMIT 1
+          ) WHERE $tab = 'users';
+
         -- User table and tab value Start here
         ${userListPagination.init()} 
         SELECT 'table' AS component, TRUE as sort, TRUE as search WHERE $tab = 'users';
@@ -510,6 +542,24 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         "$tab='users'",
       )
       };
+
+      SELECT
+            'html' AS component,
+            contents,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>' || contents || '</strong>
+            </div>' AS html
+          FROM (
+            SELECT
+              query_uri,
+              CASE
+                WHEN query_uri LIKE '%osquery%' THEN 'osquery'
+                WHEN query_uri LIKE '%Steampipe%' THEN 'Steampipe'
+                ELSE 'Other'
+              END AS contents
+            FROM ${containerViewName}
+            LIMIT 1
+          ) WHERE $tab = 'all_process';
 
       -- Container table and tab value Start here
       -- Container pagenation
@@ -529,6 +579,25 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       };
       
 
+      -- Display sourse lable of data
+      SELECT
+            'html' AS component,
+            contents,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>' || contents || '</strong>
+            </div>' AS html
+          FROM (
+            SELECT
+              query_uri,
+              CASE
+                WHEN query_uri LIKE '%osquery%' THEN 'osquery'
+                WHEN query_uri LIKE '%Steampipe%' THEN 'Steampipe'
+                ELSE 'Other'
+              END AS contents
+            FROM ${processViewName}
+            LIMIT 1
+          ) WHERE $tab = 'all_process';
+
         -- all_process table and tab value Start here
         -- all_process pagenation
         ${processPagination.init()} 
@@ -546,6 +615,15 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
 
       -- asset_service table and tab value Start here
         -- asset_service pagenation
+
+         -- Display sourse lable of data
+         SELECT
+            'html' AS component,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong> Logical Data</strong>
+            </div>' AS html
+          WHERE $tab = 'asset_service';
+
         ${assetServicePagination.init()} 
         SELECT 'table' AS component, TRUE as sort, TRUE as search WHERE $tab = 'asset_service';
         SELECT name AS "service",
@@ -557,8 +635,46 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         ${assetServicePagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
-        "$tab='asset_service'",
-      )
+        "$tab='asset_service'",)
+      };
+
+      -- ssl_tls_is_enabled table and tab value Start here
+        -- ssl_tls_is_enabled pagenation
+        ${listPorts443Pagination.init()} 
+        select 
+        'text'              as component,
+        'This view shows all services listening on port 443 (default for HTTPS), allowing you to verify if SSL/TLS is enabled on your server.' as contents WHERE $tab = 'ssl_tls_is_enabled';
+        
+         -- Display sourse lable of data
+         SELECT
+            'html' AS component,
+            contents,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>' || contents || '</strong>
+            </div>' AS html
+          FROM (
+            SELECT
+              query_uri,
+              CASE
+                WHEN query_uri LIKE '%osquery%' THEN 'osquery'
+                WHEN query_uri LIKE '%Steampipe%' THEN 'Steampipe'
+                ELSE 'Other'
+              END AS contents
+            FROM ${listPorts443ViewName}
+            LIMIT 1
+          ) WHERE $tab = 'ssl_tls_is_enabled';
+        
+        SELECT 'table' AS component, TRUE as sort, TRUE as search WHERE $tab = 'ssl_tls_is_enabled';
+        SELECT 
+        address,family,fd, net_namespace,path, port,
+        protocol,socket
+        FROM ${listPorts443ViewName}
+        WHERE host_identifier = $host_identifier AND $tab = 'ssl_tls_is_enabled'
+        LIMIT $limit OFFSET $offset;
+        ${listPorts443Pagination.renderSimpleMarkdown(
+        "tab",
+        "host_identifier",
+        "$tab='ssl_tls_is_enabled'",)
       };
       
       `;

--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -535,3 +535,35 @@ SELECT
 FROM uniform_resource,
      json_each(content,'$.rows')
 WHERE uri = 'SteampipeAwsCostByServiceMonthly';
+
+-- -- ur_transform_list_ports_443
+-- You can check if your server is listening on port 443 (default for HTTPS) to ensure SSL/TLS is enabled for web services.
+DROP TABLE IF EXISTS ur_transform_list_ports_443;
+CREATE TABLE ur_transform_list_ports_443 AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.address') AS address,  
+    CASE json_extract(content, '$.columns.family')
+        WHEN '2' THEN 'IPv4'
+        WHEN '10' THEN 'IPv6'
+        ELSE 'Unknown'
+    END AS family,
+    json_extract(content, '$.columns.fd') AS fd,
+    json_extract(content, '$.columns.net_namespace') AS net_namespace, 
+    json_extract(content, '$.columns.path') AS path, 
+    json_extract(content, '$.columns.port') AS port,
+    CASE json_extract(content, '$.columns.protocol')
+        WHEN '6' THEN 'TCP'
+        WHEN '17' THEN 'UDP'
+        ELSE json_extract(content, '$.columns.protocol')
+    END AS protocol,
+    json_extract(content, '$.columns.socket') AS socket,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery Listening Ports 443" 
+    AND uri = "osquery-ms:query-result"
+    AND json_extract(content, '$.columns.port') = '443';

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -186,7 +186,8 @@ SELECT
     ss.host_identifier,
     ss.user_name,
     ss.directory,
-    ss.uid
+    ss.uid,
+    ss.query_uri
 FROM surveilr_osquery_ms_node_boundary host
 INNER JOIN ur_transform_list_user ss ON ss.host_identifier=host.host_identifier;
 
@@ -203,7 +204,8 @@ port.port,
 ni.ip_address,
 process.process_name as process,
 user.user_name as owenrship,
-datetime(created, 'unixepoch', 'localtime') AS created_date
+datetime(created, 'unixepoch', 'localtime') AS created_date,
+c.query_uri
 FROM ur_transform_list_container AS c
 INNER JOIN ur_transform_list_container_ports AS port ON port.id=c.id
 INNER JOIN ur_transform_list_network_information AS ni ON ni.id=c.id AND ni.hostIdentifier=c.hostIdentifier
@@ -224,7 +226,8 @@ port.port,
 ni.ip_address,
 process.process_name as process,
 user.user_name as owenrship,
-datetime(created, 'unixepoch', 'localtime') AS created_date
+datetime(created, 'unixepoch', 'localtime') AS created_date,
+c.query_uri
 FROM ur_transform_list_container AS c
 INNER JOIN ur_transform_list_container_ports AS port ON port.id=c.id
 INNER JOIN ur_transform_list_network_information AS ni ON ni.id=c.id AND ni.hostIdentifier=c.hostIdentifier
@@ -400,5 +403,21 @@ CASE state
   WHEN 'P' THEN 'Parked'
   WHEN 'I' THEN 'Idle'
   ELSE 'Unknown'
-END AS state_description
+END AS state_description,
+query_uri
 FROM ur_transform_list_container_process;
+
+DROP VIEW IF EXISTS list_ports_443;
+CREATE VIEW list_ports_443 AS
+SELECT 
+host_identifier,
+name,
+address,
+family,
+fd,
+net_namespace,
+path,
+port,
+protocol,
+socket,query_uri
+FROM ur_transform_list_ports_443;


### PR DESCRIPTION
- introduced a new tab on the host detail page to display ssl/tls listening status
- the view lists services listening on port 443 to help verify https/ssl configuration
- helpful for visibility, diagnostics, and compliance tracking