### PR TITLE
feat : add fleetfolio support for displaying SSL certificate file metadata using osquery #355

### DIFF
--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -567,3 +567,30 @@ WHERE
     AND name = "Osquery Listening Ports 443" 
     AND uri = "osquery-ms:query-result"
     AND json_extract(content, '$.columns.port') = '443';
+
+
+-- -- ur_transform_list_ssl_cert_files
+DROP TABLE IF EXISTS ur_transform_list_ssl_cert_files;
+CREATE TABLE ur_transform_list_ssl_cert_files AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.block_size') AS block_size,  
+    json_extract(content, '$.columns.device') AS device,
+    json_extract(content, '$.columns.directory') AS directory, 
+    json_extract(content, '$.columns.filename') AS filename, 
+    json_extract(content, '$.columns.gid') AS gid,
+    json_extract(content, '$.columns.hard_links') AS hard_links,
+    json_extract(content, '$.columns.inode') AS inode,
+    json_extract(content, '$.columns.mode') AS mode,
+    json_extract(content, '$.columns.path') AS path,
+    json_extract(content, '$.columns.size') AS size,
+    json_extract(content, '$.columns.type') AS type,
+    json_extract(content, '$.columns.uid') AS uid,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery SSL Cert Files" 
+    AND uri = "osquery-ms:query-result";

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -410,14 +410,36 @@ FROM ur_transform_list_container_process;
 DROP VIEW IF EXISTS list_ports_443;
 CREATE VIEW list_ports_443 AS
 SELECT 
-host_identifier,
-name,
-address,
-family,
-fd,
-net_namespace,
-path,
-port,
-protocol,
-socket,query_uri
+  host_identifier,
+  name,
+  address,
+  family,
+  fd,
+  net_namespace,
+  path,
+  port,
+  protocol,
+  socket,query_uri
 FROM ur_transform_list_ports_443;
+
+DROP VIEW IF EXISTS list_ssl_cert_files;
+CREATE VIEW list_ssl_cert_files AS
+SELECT 
+  lp4.host_identifier,
+  lp4.name,
+  lp4.block_size,
+  lp4.device,
+  lp4.directory,
+  lp4.filename,
+  lp4.gid,
+  lp4.hard_links,
+  lp4.inode,
+  lp4.mode,
+  lp4.path,
+  lp4.size,
+  lp4.type,
+  lp4.uid,
+  user.user_name,
+  lp4.query_uri
+FROM ur_transform_list_ssl_cert_files lp4
+LEFT JOIN ur_transform_list_user user ON user.uid = lp4.uid;


### PR DESCRIPTION
### Summary

This PR introduces support in the Fleetfolio dashboard for displaying SSL certificate file metadata collected via osquery. It provides visibility into file attributes under `/etc/ssl/certs` and `/etc/ssl/private`, which are commonly used for storing TLS/SSL certificates and private keys.

### Key Features

- Integrates osquery results from the `file` table filtered by certificate-related paths.
- Displays detailed metadata such as:
  - Path, directory, filename
  - Inode, UID, GID
  - File mode (permissions)
  - Size, block size, hard links
  - File type (e.g., directory or file)
- Enables compliance teams to validate correct permissions and secure storage of SSL assets.

### Dashboard Enhancement

- Added a table widget under the "Encryption & Certificates" section.
- Includes a helpful description above the table:
  
  > **Description:**  
  > This table displays metadata for files and directories under `/etc/ssl/certs` and `/etc/ssl/private`. It helps verify SSL certificate file ownership, permissions, and structural integrity across Linux systems. Use this to detect unauthorized changes or misconfigurations in certificate storage paths.

### Query Used

```sql
SELECT path, directory, filename, inode, uid, gid, mode, device, size, block_size, hard_links, type
FROM file
WHERE path LIKE '/etc/ssl/certs%' OR path LIKE '/etc/ssl/private%';
