### PR TITLE
feat: add osquery_vpn_listening_ports table to fleetfolio dashboard #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -297,6 +297,13 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       whereSQL: "WHERE host_identifier=$host_identifier",
     });
 
+    const listVpnListeningPorts = `list_vpn_listening_ports`;
+    const listVpnListeningPortsPagination = this.pagination({
+      tableOrViewName: listVpnListeningPorts,
+      whereSQL: "WHERE host_identifier=$host_identifier",
+    });
+
+
     return this.SQL`
       ${this.activePageTitle()}
         --- Display breadcrumb
@@ -459,7 +466,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         select 'SSL/TLS is enabled' as title, '?tab=ssl_tls_is_enabled&host_identifier=' || $host_identifier AS link, $tab = 'ssl_tls_is_enabled' as active;
         select 'SSL Certificate Files' as title, '?tab=osquery_ssl_cert_files&host_identifier=' || $host_identifier AS link, $tab = 'osquery_ssl_cert_files' as active;
         select 'SSL Certificate and Key File Modification Times' as title, '?tab=ssl_certificate_and_key_file_modification_times&host_identifier=' || $host_identifier AS link, $tab = 'ssl_certificate_and_key_file_modification_times' as active;
-
+        select 'VPN Listening Ports' as title, '?tab=vpn_listening_ports&host_identifier=' || $host_identifier AS link, $tab = 'vpn_listening_ports' as active;
 
         -- policy table and tab value Start here
         -- policy pagenation
@@ -626,7 +633,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       )
       };
 
-      -- asset_service table and tab value Start here
+        -- asset_service table and tab value Start here
         -- asset_service pagenation
 
          -- Display sourse lable of data
@@ -650,6 +657,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         "host_identifier",
         "$tab='asset_service'",)
       };
+
+
 
       -- ssl_tls_is_enabled table and tab value Start here
         -- ssl_tls_is_enabled pagenation
@@ -691,6 +700,7 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       };
 
 
+      -- osquery_ssl_cert_files table and tab value Start here
       select
         'text'              as component,
         'This table displays metadata for files and directories under /etc/ssl/certs and /etc/ssl/private. It helps verify SSL certificate file ownership, permissions, and structural integrity across Linux systems. Use this to detect unauthorized changes or misconfigurations in certificate storage paths.' as contents WHERE $tab = 'osquery_ssl_cert_files';
@@ -713,7 +723,6 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             LIMIT 1
           ) WHERE $tab = 'osquery_ssl_cert_files';
 
-        -- osquery_ssl_cert_files table and tab value Start here
         -- osquery_ssl_cert_files pagenation
         ${listListSSLCertFilePagination.init()} 
         SELECT 'table' AS component, TRUE as sort, TRUE as search WHERE $tab = 'osquery_ssl_cert_files';
@@ -778,6 +787,52 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         "tab",
         "host_identifier",
         "$tab='ssl_certificate_and_key_file_modification_times'",
+      )
+      };
+
+
+      -- ssl_certificate_and_key_file_modification_times table and tab value Start here
+
+      select
+        'text'              as component,
+        'Displays information about system ports commonly used by VPN services (e.g., 1194, 443, 500, 4500), including protocol, address, file descriptor, and socket details. Useful for validating VPN service bindings and potential security exposure.' as contents WHERE $tab = 'vpn_listening_ports';
+      -- Display sourse lable of data
+      SELECT
+            'html' AS component,
+            contents,
+            '<div style="width: 100%; padding-top: 20px; text-align: right; font-size: 14px; color: #666;">
+            Source: <strong>' || contents || '</strong>
+            </div>' AS html
+          FROM (
+            SELECT
+              query_uri,
+              CASE
+                WHEN query_uri LIKE '%osquery%' THEN 'osquery'
+                WHEN query_uri LIKE '%Steampipe%' THEN 'Steampipe'
+                ELSE 'Other'
+              END AS contents
+            FROM ${listVpnListeningPorts}
+            LIMIT 1
+          ) WHERE $tab = 'vpn_listening_ports';
+        -- vpn_listening_ports pagenation
+        ${listVpnListeningPortsPagination.init()} 
+        SELECT 'table' AS component, TRUE as sort, TRUE as search WHERE $tab = 'vpn_listening_ports';
+        SELECT 
+          port,
+          protocol,
+          family,
+          address,
+          fd,
+          socket,
+          path,
+          net_namespace as "Net Namespace"
+        FROM ${listVpnListeningPorts}
+        WHERE host_identifier = $host_identifier AND $tab = 'vpn_listening_ports'
+        LIMIT $limit OFFSET $offset;
+        ${listVpnListeningPortsPagination.renderSimpleMarkdown(
+        "tab",
+        "host_identifier",
+        "$tab='vpn_listening_ports'",
       )
       };
       

--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -595,8 +595,8 @@ WHERE
     AND name = "Osquery SSL Cert Files" 
     AND uri = "osquery-ms:query-result";
 
-  -- -- Monitor SSL cert and key file modification times
-  --  ur_transform_list_ssl_cert_file_mtime
+-- -- Monitor SSL cert and key file modification times
+--  ur_transform_list_ssl_cert_file_mtime
 DROP TABLE IF EXISTS ur_transform_list_ssl_cert_file_mtime;
 CREATE TABLE ur_transform_list_ssl_cert_file_mtime AS
 SELECT 
@@ -610,4 +610,35 @@ FROM uniform_resource
 WHERE 
     json_valid(content) = 1 
     AND name = "Osquery SSL Cert File MTIME" 
+    AND uri = "osquery-ms:query-result";
+
+-- -- Check if common VPN service ports (443, 1194, 500, 4500) are listening
+--  ur_transform_list_osquery_vpn_listening_ports
+DROP TABLE IF EXISTS ur_transform_list_osquery_vpn_listening_ports;
+CREATE TABLE ur_transform_list_osquery_vpn_listening_ports AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.address') AS address,  
+    json_extract(content, '$.columns.family') AS family,
+    CASE json_extract(content, '$.columns.family')
+        WHEN '2' THEN 'IPv4'
+        ELSE json_extract(content, '$.columns.family')
+    END AS family,
+    json_extract(content, '$.columns.fd') AS fd,
+    json_extract(content, '$.columns.net_namespace') AS net_namespace,
+    json_extract(content, '$.columns.path') AS path,
+    json_extract(content, '$.columns.port') AS port,
+    CASE json_extract(content, '$.columns.protocol')
+        WHEN '6' THEN 'TCP'
+        WHEN '17' THEN 'UDP'
+        ELSE json_extract(content, '$.columns.protocol')
+    END AS protocol,
+    json_extract(content, '$.columns.socket') AS socket,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery VPN Listening Ports" 
     AND uri = "osquery-ms:query-result";

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -454,3 +454,19 @@ SELECT
   path,
   query_uri
 FROM ur_transform_list_ssl_cert_file_mtime;
+
+DROP VIEW IF EXISTS list_vpn_listening_ports;
+CREATE VIEW list_vpn_listening_ports AS
+SELECT 
+  host_identifier,
+  name,
+  address,
+  family,
+  fd,
+  net_namespace,
+  path,
+  port,
+  protocol,
+  socket,
+  query_uri
+FROM ur_transform_list_osquery_vpn_listening_ports;


### PR DESCRIPTION
### Summary
Added a new table to the Fleetfolio dashboard: **Osquery VPN Listening Ports**.

### Details
- Displays listening ports related to VPN services using Osquery.
- Ports filtered: 1194 (OpenVPN), 443 (HTTPS), 500 and 4500 (IPSec).
- Provides insights into network bindings for VPN-related services.

### Osquery Query Used
```sql
SELECT port, protocol, family, address, fd, socket, path, net_namespace 
FROM listening_ports 
WHERE port IN (1194, 443, 500, 4500);
