### PR TITLE
feat: add human readable cron schedule formatting for cron backup jobs in fleetfolio #355

### DIFF
--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -613,7 +613,7 @@ WHERE
     AND uri = "osquery-ms:query-result";
 
 -- -- Check if common VPN service ports (443, 1194, 500, 4500) are listening
---  ur_transform_list_osquery_vpn_listening_ports
+-- ur_transform_list_osquery_vpn_listening_ports
 DROP TABLE IF EXISTS ur_transform_list_osquery_vpn_listening_ports;
 CREATE TABLE ur_transform_list_osquery_vpn_listening_ports AS
 SELECT 
@@ -641,4 +641,59 @@ FROM uniform_resource
 WHERE 
     json_valid(content) = 1 
     AND name = "Osquery VPN Listening Ports" 
+    AND uri = "osquery-ms:query-result";
+
+-- Check for cron jobs related to backup tasks
+-- ur_transform_list_osquery_vpn_listening_ports
+DROP TABLE IF EXISTS ur_transform_list_osquery_vpn_listening_ports;
+CREATE TABLE ur_transform_list_osquery_vpn_listening_ports AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.address') AS address,  
+    json_extract(content, '$.columns.family') AS family,
+    CASE json_extract(content, '$.columns.family')
+        WHEN '2' THEN 'IPv4'
+        ELSE json_extract(content, '$.columns.family')
+    END AS family,
+    json_extract(content, '$.columns.fd') AS fd,
+    json_extract(content, '$.columns.net_namespace') AS net_namespace,
+    json_extract(content, '$.columns.path') AS path,
+    json_extract(content, '$.columns.port') AS port,
+    CASE json_extract(content, '$.columns.protocol')
+        WHEN '6' THEN 'TCP'
+        WHEN '17' THEN 'UDP'
+        ELSE json_extract(content, '$.columns.protocol')
+    END AS protocol,
+    json_extract(content, '$.columns.socket') AS socket,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery VPN Listening Ports" 
+    AND uri = "osquery-ms:query-result";
+
+
+-- Check for cron jobs related to backup tasks
+-- ur_transform_list_cron_backup_jobs
+DROP TABLE IF EXISTS ur_transform_list_cron_backup_jobs;
+CREATE TABLE ur_transform_list_cron_backup_jobs AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.command') AS command,  
+    json_extract(content, '$.columns.day_of_month') AS day_of_month,
+    json_extract(content, '$.columns.day_of_week') AS day_of_week, 
+    json_extract(content, '$.columns.event') AS event, 
+    json_extract(content, '$.columns.hour') AS hour,  
+    json_extract(content, '$.columns.minute') AS minute,
+    json_extract(content, '$.columns.month') AS month,
+    json_extract(content, '$.columns.path') AS path,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery Cron Backup Jobs" 
     AND uri = "osquery-ms:query-result";

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -470,3 +470,29 @@ SELECT
   socket,
   query_uri
 FROM ur_transform_list_osquery_vpn_listening_ports;
+
+DROP VIEW IF EXISTS list_cron_backup_jobs;
+CREATE VIEW list_cron_backup_jobs AS
+SELECT
+    uniform_resource_id,
+    name,
+    host_identifier,
+    command,
+    event,
+    minute,
+    hour,
+    day_of_month,
+    month,
+    day_of_week,
+    path,
+    query_uri,
+    minute || ' ' || hour || ' ' || day_of_month || ' ' || month || ' ' || day_of_week AS cron_schedule,
+
+    CASE
+        WHEN hour GLOB '[0-9]*' AND minute GLOB '[0-9]*' THEN
+            'Runs at ' || printf('%02d', hour) || ':' || printf('%02d', minute)
+        ELSE
+            'Runs on schedule: ' || minute || ' ' || hour || ' ' || day_of_month || ' ' || month || ' ' || day_of_week
+    END AS human_readable_schedule
+
+FROM ur_transform_list_cron_backup_jobs;


### PR DESCRIPTION
### Summary
Enhanced the `osquery_cron_backup_jobs` view in Fleetfolio by adding a human-readable cron schedule column.

### Details
- Added a new field `human_readable_schedule` that converts raw cron timing fields into readable text.
- When both `hour` and `minute` are numeric, displays as: `Runs at HH:MM`
- If values contain wildcards or special patterns (like */5), falls back to: `Runs on schedule: <cron_expression>`

### Example Outputs
- `Runs at 02:30` → for jobs scheduled at 2:30 AM daily.
- `Runs on schedule: */15 * * * *` → for jobs running every 15 minutes.

### Benefit
Improves clarity and usability when reviewing cron job schedules in Fleetfolio dashboards.


