### PR TITLE
refactor: reduce fields in 'Osquery Interface Details Inventory' to avoid duplication and check DB size #355

### DIFF
--- a/lib/pattern/osquery-ms/queries.sql.ts
+++ b/lib/pattern/osquery-ms/queries.sql.ts
@@ -366,21 +366,12 @@ export class SurveilrOsqueryMsQueries extends cnb.TypicalCodeNotebook {
       interface, 
       mac, 
       type, 
-      mtu, 
-      metric, 
-      flags, 
-      ipackets, 
-      opackets, 
-      ibytes, 
-      obytes, 
-      ierrors, 
-      oerrors, 
-      idrops, 
-      odrops, 
-      collisions, 
-      last_change, 
-      link_speed, 
-      pci_slot 
+      mtu,
+      link_speed,
+      ierrors,
+      oerrors,
+      idrops,
+      odrops
     FROM interface_details;`;
   }
 


### PR DESCRIPTION

This PR modifies the `Osquery Interface Details Inventory` query by removing certain unused or redundant fields. The purpose of this change is to:

* Avoid duplication of interface metrics across hosts
* Reduce the volume of stored data
* Investigate and potentially improve the overall RSSD database size

This is part of ongoing efforts to optimize performance and storage efficiency in Fleetfolio.
