### PR TITLE
feat: convert tabs to searchable dropdown and enhance search functionality #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -42,9 +42,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
   navigationDML() {
     return this.SQL`
       -- delete all /fleetfolio-related entries and recreate them in case routes are changed
-      DELETE FROM sqlpage_aide_navigation WHERE parent_path like ${
-      this.constructHomePath("fleetfolio")
-    };
+      DELETE FROM sqlpage_aide_navigation WHERE parent_path like ${this.constructHomePath("fleetfolio")
+      };
       ${this.upsertNavSQL(...Array.from(this.navigation.values()))}
     `;
   }
@@ -62,19 +61,16 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
       WITH navigation_cte AS (
           SELECT COALESCE(title, caption) as title, description
             FROM sqlpage_aide_navigation
-           WHERE namespace = 'prime' AND path = ${
-      this.constructHomePath("fleetfolio")
-    }
+           WHERE namespace = 'prime' AND path = ${this.constructHomePath("fleetfolio")
+      }
       )
       SELECT 'list' AS component, title, description
         FROM navigation_cte;
-      SELECT caption as title, ${
-      this.absoluteURL("/")
-    } || COALESCE(url, path) as link, description
+      SELECT caption as title, ${this.absoluteURL("/")
+      } || COALESCE(url, path) as link, description
         FROM sqlpage_aide_navigation
-       WHERE namespace = 'prime' AND parent_path = ${
-      this.constructHomePath("fleetfolio")
-    }
+       WHERE namespace = 'prime' AND parent_path = ${this.constructHomePath("fleetfolio")
+      }
        ORDER BY sibling_order;`;
   }
 
@@ -104,9 +100,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
                 4      as columns;
             select
                 boundary  as title,
-                ${
-      this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
-    } || boundary_key as link
+                ${this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
+      } || boundary_key as link
             FROM boundary_list;
 
         -- AWS Trust Boundary
@@ -117,9 +112,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             "AWS Trust Boundary"  as title,
             'brand-aws' as icon,
             'orange' as color,
-            ${
-      this.absoluteURL("/fleetfolio/aws_trust_boundary_list.sql")
-    } as link
+            ${this.absoluteURL("/fleetfolio/aws_trust_boundary_list.sql")
+      } as link
          ;
             `;
   }
@@ -173,9 +167,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             TRUE as sort,
             TRUE as search;
         SELECT
-        '[' || host || '](' || ${
-      this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
-    } || host_identifier || '&path=direct)' as host,
+        '[' || host || '](' || ${this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
+      } || host_identifier || '&path=direct)' as host,
         boundary,
         logical_boundary as "logical boundary",
         CASE 
@@ -216,9 +209,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         SELECT 'Boundary' AS title,
             ${this.absoluteURL("/fleetfolio/boundary.sql")} AS link;
         SELECT boundary AS title,
-            ${
-      this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
-    } || boundary_key  AS link
+            ${this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
+      } || boundary_key  AS link
           FROM host_list WHERE boundary_key=$boundary_key LIMIT 1;
 
 
@@ -237,9 +229,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             TRUE as sort,
             TRUE as search;
         SELECT 
-        '[' || host || '](' || ${
-      this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
-    } || host_identifier || '&path=boundary)' as host,
+        '[' || host || '](' || ${this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
+      } || host_identifier || '&path=boundary)' as host,
         boundary,
         CASE 
             WHEN status = 'Online' THEN '🟢 Online'
@@ -337,18 +328,15 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             ${this.absoluteURL("/fleetfolio/index.sql")} AS link;  
         SELECT
             'Boundary' AS title,
-            ${
-      this.absoluteURL("/fleetfolio/boundary.sql")
-    } AS link WHERE $path='boundary'; 
+            ${this.absoluteURL("/fleetfolio/boundary.sql")
+      } AS link WHERE $path='boundary'; 
         SELECT boundary AS title,
-            ${
-      this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
-    } || boundary_key  AS link
+            ${this.absoluteURL("/fleetfolio/host_list.sql?boundary_key=")
+      } || boundary_key  AS link
             FROM host_list WHERE host_identifier=$host_identifier AND $path='boundary' LIMIT 1;
         SELECT host AS title,
-            ${
-      this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
-    } || host_identifier  AS link
+            ${this.absoluteURL("/fleetfolio/host_detail.sql?host_identifier=")
+      } || host_identifier  AS link
             FROM host_list WHERE host_identifier=$host_identifier LIMIT 1;
 
 
@@ -480,19 +468,196 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         'divider' as component,
         'System Environment'   as contents; 
 
-        SELECT 'tab' AS component, TRUE AS center;
-        SELECT 'Policies' AS title, '?tab=policies&host_identifier=' || $host_identifier AS link, ($tab = 'policies' OR $tab IS NULL) AS active;
-        select 'Software' as title, '?tab=software&host_identifier=' || $host_identifier AS link, $tab = 'software' as active;
-        select 'Users' as title, '?tab=users&host_identifier=' || $host_identifier AS link, $tab = 'users' as active;
-        select 'Containers' as title, '?tab=container&host_identifier=' || $host_identifier AS link, $tab = 'container' as active;
-        select 'All Process' as title, '?tab=all_process&host_identifier=' || $host_identifier AS link, $tab = 'all_process' as active;
-        select 'Asset Service' as title, '?tab=asset_service&host_identifier=' || $host_identifier AS link, $tab = 'asset_service' as active;
-        select 'SSL/TLS is enabled' as title, '?tab=ssl_tls_is_enabled&host_identifier=' || $host_identifier AS link, $tab = 'ssl_tls_is_enabled' as active;
-        select 'SSL Certificate Files' as title, '?tab=osquery_ssl_cert_files&host_identifier=' || $host_identifier AS link, $tab = 'osquery_ssl_cert_files' as active;
-        select 'SSL Certificate and Key File Modification Times' as title, '?tab=ssl_certificate_and_key_file_modification_times&host_identifier=' || $host_identifier AS link, $tab = 'ssl_certificate_and_key_file_modification_times' as active;
-        select 'VPN Listening Ports' as title, '?tab=vpn_listening_ports&host_identifier=' || $host_identifier AS link, $tab = 'vpn_listening_ports' as active;
-        select 'Cron Jobs Related to Backup Tasks' as title, '?tab=cron_backup_jobs&host_identifier=' || $host_identifier AS link, $tab = 'cron_backup_jobs' as active;
-        select 'MySQL Process Inventory' as title, '?tab=mysql_process_inventory&host_identifier=' || $host_identifier AS link, $tab = 'mysql_process_inventory' as active;
+        -- Aggressive CSS targeting for SQLPage form horizontal layout
+        SELECT 'html' AS component,
+            '<div class="force-horizontal-layout">
+                <style>
+                    /* Aggressive targeting of all possible SQLPage form structures */
+                    .force-horizontal-layout ~ form,
+                    .force-horizontal-layout + form,
+                    form:has(select[name="tab"]) {
+                        display: flex !important;
+                        flex-direction: row !important;
+                        align-items: flex-end !important;
+                        gap: 15px !important;
+                        flex-wrap: wrap !important;
+                        max-width: 600px !important;
+                        margin-bottom: 20px !important;
+                        background: #f8f9fa !important;
+                        padding: 15px !important;
+                        border-radius: 6px !important;
+                        border: 1px solid #dee2e6 !important;
+                    }
+
+                    /* Target all possible container elements */
+                    .force-horizontal-layout ~ form > *,
+                    .force-horizontal-layout + form > *,
+                    form:has(select[name="tab"]) > * {
+                        display: flex !important;
+                        flex-direction: row !important;
+                        align-items: flex-end !important;
+                        gap: 15px !important;
+                        margin: 0 !important;
+                        flex: 0 0 auto !important;
+                    }
+
+                    /* Target Bootstrap/SQLPage row and col classes */
+                    .force-horizontal-layout ~ form .row,
+                    .force-horizontal-layout + form .row,
+                    .force-horizontal-layout ~ form .col,
+                    .force-horizontal-layout + form .col,
+                    .force-horizontal-layout ~ form .col-12,
+                    .force-horizontal-layout + form .col-12,
+                    form:has(select[name="tab"]) .row,
+                    form:has(select[name="tab"]) .col,
+                    form:has(select[name="tab"]) .col-12 {
+                        display: flex !important;
+                        flex-direction: row !important;
+                        align-items: flex-end !important;
+                        gap: 15px !important;
+                        width: auto !important;
+                        margin: 0 !important;
+                        flex: 0 0 auto !important;
+                        min-width: 500px !important;
+                    }
+
+                    /* Target form groups */
+                    .force-horizontal-layout ~ form .form-group,
+                    .force-horizontal-layout + form .form-group,
+                    form:has(select[name="tab"]) .form-group {
+                        margin-bottom: 0 !important;
+                        margin-right: 0 !important;
+                        min-width: 730px !important;
+                        flex: 0 0 auto !important;
+                    }
+
+                    /* Target labels */
+                    .force-horizontal-layout ~ form label,
+                    .force-horizontal-layout + form label,
+                    form:has(select[name="tab"]) label {
+                        margin-bottom: 5px !important;
+                        font-weight: 500 !important;
+                        font-size: 14px !important;
+                        color: #495057 !important;
+                        display: block !important;
+                        width: 100% !important;
+                    }
+
+                    /* Target select elements */
+                    .force-horizontal-layout ~ form select,
+                    .force-horizontal-layout + form select,
+                    form:has(select[name="tab"]) select {
+                        width: 300px !important;
+                        max-width: 300px !important;
+                        height: 38px !important;
+                        margin-bottom: 0 !important;
+                        flex: 0 0 auto !important;
+                    }
+
+                    /* Target buttons */
+                    .force-horizontal-layout ~ form button,
+                    .force-horizontal-layout + form button,
+                    form:has(select[name="tab"]) button {
+                        height: 38px !important;
+                        padding: 8px 16px !important;
+                        margin-bottom: 0 !important;
+                        margin-left: 0 !important;
+                        white-space: nowrap !important;
+                        flex: 0 0 auto !important;
+                        align-self: flex-end !important;
+                    }
+
+                    /* Hide hidden inputs */
+                    .force-horizontal-layout ~ form input[type="hidden"],
+                    .force-horizontal-layout + form input[type="hidden"],
+                    form:has(select[name="tab"]) input[type="hidden"] {
+                        display: none !important;
+                    }
+
+                    /* Alternative CSS Grid approach */
+                    .force-horizontal-layout ~ form,
+                    .force-horizontal-layout + form,
+                    form:has(select[name="tab"]) {
+                        display: grid !important;
+                        grid-template-columns: 1fr auto !important;
+                        gap: 15px !important;
+                        align-items: end !important;
+                    }
+
+                    /* Responsive behavior for mobile */
+                    @media (max-width: 768px) {
+                        .force-horizontal-layout ~ form,
+                        .force-horizontal-layout + form,
+                        form:has(select[name="tab"]) {
+                            display: flex !important;
+                            flex-direction: column !important;
+                            align-items: stretch !important;
+                            grid-template-columns: none !important;
+                        }
+
+                        .force-horizontal-layout ~ form .form-group,
+                        .force-horizontal-layout + form .form-group,
+                        form:has(select[name="tab"]) .form-group {
+                            min-width: 100% !important;
+                            margin-bottom: 10px !important;
+                        }
+
+                        .force-horizontal-layout ~ form select,
+                        .force-horizontal-layout + form select,
+                        form:has(select[name="tab"]) select {
+                            width: 100% !important;
+                        }
+                    }
+                </style>
+            </div>' AS html;
+
+        -- Searchable SQLPage form component with horizontal layout
+        SELECT 'form' AS component, 'GET' AS method;
+
+        -- Hidden field to preserve host_identifier
+        SELECT 'hidden' AS type, 'host_identifier' AS name, $host_identifier AS value;
+
+        -- Searchable dropdown select field with all view options
+        SELECT
+            'select' AS type,
+            'tab' AS name,
+            'Select View:' AS label,
+            COALESCE($tab, 'policies') AS value,
+            'Search views...' AS placeholder,
+            TRUE AS searchable,
+            'onchange="this.form.submit()"' AS attributes,
+            JSON_ARRAY(
+                JSON_OBJECT('value', 'policies', 'label', 'Policies'),
+                JSON_OBJECT('value', 'software', 'label', 'Software'),
+                JSON_OBJECT('value', 'users', 'label', 'Users'),
+                JSON_OBJECT('value', 'container', 'label', 'Containers'),
+                JSON_OBJECT('value', 'all_process', 'label', 'All Process'),
+                JSON_OBJECT('value', 'asset_service', 'label', 'Asset Service'),
+                JSON_OBJECT('value', 'ssl_tls_is_enabled', 'label', 'SSL/TLS is enabled'),
+                JSON_OBJECT('value', 'osquery_ssl_cert_files', 'label', 'SSL Certificate Files'),
+                JSON_OBJECT('value', 'ssl_certificate_and_key_file_modification_times', 'label', 'SSL Certificate and Key File Modification Times'),
+                JSON_OBJECT('value', 'vpn_listening_ports', 'label', 'VPN Listening Ports'),
+                JSON_OBJECT('value', 'cron_backup_jobs', 'label', 'Cron Jobs Related to Backup Tasks'),
+                JSON_OBJECT('value', 'mysql_process_inventory', 'label', 'MySQL Process Inventory')
+            ) AS options;
+
+        -- Dynamic title display based on selected view
+        SELECT 'title' AS component,
+            CASE
+                WHEN $tab = 'policies' OR $tab IS NULL THEN 'Policies'
+                WHEN $tab = 'software' THEN 'Software'
+                WHEN $tab = 'users' THEN 'Users'
+                WHEN $tab = 'container' THEN 'Containers'
+                WHEN $tab = 'all_process' THEN 'All Process'
+                WHEN $tab = 'asset_service' THEN 'Asset Service'
+                WHEN $tab = 'ssl_tls_is_enabled' THEN 'SSL/TLS is enabled'
+                WHEN $tab = 'osquery_ssl_cert_files' THEN 'SSL Certificate Files'
+                WHEN $tab = 'ssl_certificate_and_key_file_modification_times' THEN 'SSL Certificate and Key File Modification Times'
+                WHEN $tab = 'vpn_listening_ports' THEN 'VPN Listening Ports'
+                WHEN $tab = 'cron_backup_jobs' THEN 'Cron Jobs Related to Backup Tasks'
+                WHEN $tab = 'mysql_process_inventory' THEN 'MySQL Process Inventory'
+                ELSE 'Policies'
+            END AS contents;
 
         -- policy table and tab value Start here
         -- policy pagenation
@@ -523,13 +688,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         WHERE host_identifier = $host_identifier AND ($tab = 'policies' OR $tab IS NULL) LIMIT $limit
         OFFSET $offset;
         -- checking
-        ${
-      policyPagination.renderSimpleMarkdown(
+        ${policyPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='policies'",
       )
-    };
+      };
 
 
       SELECT
@@ -549,13 +713,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         LIMIT $limit OFFSET $offset;
 
         -- Software pagenation
-        ${
-      softwarePagination.renderSimpleMarkdown(
+        ${softwarePagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='software'",
       )
-    };
+      };
 
       SELECT
             'html' AS component,
@@ -584,13 +747,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         LIMIT $limit OFFSET $offset;
 
         -- User pagenation
-        ${
-      userListPagination.renderSimpleMarkdown(
+        ${userListPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='users'",
       )
-    };
+      };
 
       SELECT
             'html' AS component,
@@ -620,13 +782,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${containerViewName}
         WHERE host_identifier = $host_identifier AND $tab = 'container'
         LIMIT $limit OFFSET $offset;
-        ${
-      containerPagination.renderSimpleMarkdown(
+        ${containerPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='container'",
       )
-    };
+      };
       
 
       -- Display sourse lable of data
@@ -656,13 +817,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${processViewName}
         WHERE host_identifier = $host_identifier AND $tab = 'all_process'
         LIMIT $limit OFFSET $offset;
-        ${
-      processPagination.renderSimpleMarkdown(
+        ${processPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='all_process'",
       )
-    };
+      };
 
         -- asset_service table and tab value Start here
         -- asset_service pagenation
@@ -683,13 +843,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${assetServiceViewName}
         WHERE host_identifier = $host_identifier AND $tab = 'asset_service'
         LIMIT $limit OFFSET $offset;
-        ${
-      assetServicePagination.renderSimpleMarkdown(
+        ${assetServicePagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='asset_service'",
       )
-    };
+      };
 
 
 
@@ -726,13 +885,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listPorts443ViewName}
         WHERE host_identifier = $host_identifier AND $tab = 'ssl_tls_is_enabled'
         LIMIT $limit OFFSET $offset;
-        ${
-      listPorts443Pagination.renderSimpleMarkdown(
+        ${listPorts443Pagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='ssl_tls_is_enabled'",
       )
-    };
+      };
 
 
       -- osquery_ssl_cert_files table and tab value Start here
@@ -777,13 +935,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listListSSLCertFile}
         WHERE host_identifier = $host_identifier AND $tab = 'osquery_ssl_cert_files'
         LIMIT $limit OFFSET $offset;
-        ${
-      listListSSLCertFilePagination.renderSimpleMarkdown(
+        ${listListSSLCertFilePagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='osquery_ssl_cert_files'",
       )
-    };
+      };
 
 
 
@@ -819,13 +976,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listListSSLCertFileMtime}
         WHERE host_identifier = $host_identifier AND $tab = 'ssl_certificate_and_key_file_modification_times'
         LIMIT $limit OFFSET $offset;
-        ${
-      listListSSLCertFileMtimePagination.renderSimpleMarkdown(
+        ${listListSSLCertFileMtimePagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='ssl_certificate_and_key_file_modification_times'",
       )
-    };
+      };
 
 
       -- ssl_certificate_and_key_file_modification_times table and tab value Start here
@@ -866,13 +1022,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listVpnListeningPorts}
         WHERE host_identifier = $host_identifier AND $tab = 'vpn_listening_ports'
         LIMIT $limit OFFSET $offset;
-        ${
-      listVpnListeningPortsPagination.renderSimpleMarkdown(
+        ${listVpnListeningPortsPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='vpn_listening_ports'",
       )
-    };
+      };
 
 
 
@@ -915,13 +1070,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listCronBackupJobs}
         WHERE host_identifier = $host_identifier AND $tab = 'cron_backup_jobs'
         LIMIT $limit OFFSET $offset;
-        ${
-      listCronBackupJobsPagination.renderSimpleMarkdown(
+        ${listCronBackupJobsPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='cron_backup_jobs'",
       )
-    };
+      };
 
       -- mysql_process_inventory table and tab value Start here
       select
@@ -954,13 +1108,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         FROM ${listMysqlProcessInventory}
         WHERE host_identifier = $host_identifier AND $tab = 'mysql_process_inventory'
         LIMIT $limit OFFSET $offset;
-        ${
-      listMysqlProcessInventoryPagination.renderSimpleMarkdown(
+        ${listMysqlProcessInventoryPagination.renderSimpleMarkdown(
         "tab",
         "host_identifier",
         "$tab='mysql_process_inventory'",
       )
-    };
+      };
       
       `;
   }
@@ -999,9 +1152,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             "AWS EC2 instance "  as title,
             'square' as icon,
             'orange'                    as color,
-            ${
-      this.absoluteURL("/fleetfolio/aws_ec2_instance_list.sql")
-    } as link;
+            ${this.absoluteURL("/fleetfolio/aws_ec2_instance_list.sql")
+      } as link;
         select
             "AWS S3 buckets"  as title,
             "bucket" as icon,
@@ -1016,9 +1168,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             "AWS EC2 Application Load Balancer"  as title,
             "load-balancer" as icon,
             'orange'                    as color,
-            ${
-      this.absoluteURL("/fleetfolio/aws_ec2_application_load_balancer.sql")
-    } as link;
+            ${this.absoluteURL("/fleetfolio/aws_ec2_application_load_balancer.sql")
+      } as link;
         select
             "AWS Cost"  as title,
             "settings-dollar" as icon,
@@ -1028,9 +1179,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             "AWS Monthely Cost Detail"  as title,
             "settings-dollar" as icon,
             'black'                    as color,
-            ${
-      this.absoluteURL("/fleetfolio/aws_monthely_cost_detail_list.sql")
-    } as link;
+            ${this.absoluteURL("/fleetfolio/aws_monthely_cost_detail_list.sql")
+      } as link;
      `;
   }
 
@@ -1082,9 +1232,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
             TRUE as search,
             'title' as markdown;
         SELECT 
-        '[' || title || '](' || ${
-      this.absoluteURL("/fleetfolio/aws_ec2_instance_detail.sql?instance_id=")
-    } || instance_id || ')' as title,
+        '[' || title || '](' || ${this.absoluteURL("/fleetfolio/aws_ec2_instance_detail.sql?instance_id=")
+      } || instance_id || ')' as title,
         architecture,
         platform_details AS platform, 
         root_device_name as "root device name",
@@ -1120,9 +1269,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         ${this.absoluteURL("/fleetfolio/aws_ec2_instance_list.sql")} AS link; 
       SELECT
         title,
-        ${
-      this.absoluteURL("/fleetfolio/aws_ec2_instance_detail.sql?instance_id=")
-    } || instance_id AS link FROM list_aws_ec2_instance WHERE instance_id=$instance_id; 
+        ${this.absoluteURL("/fleetfolio/aws_ec2_instance_detail.sql?instance_id=")
+      } || instance_id AS link FROM list_aws_ec2_instance WHERE instance_id=$instance_id; 
 
       --- Dsply Page Title
         SELECT
@@ -1356,9 +1504,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
 
       SELECT
         'AWS EC2 Application Load Balancer' AS title,
-        ${
-      this.absoluteURL("/fleetfolio/aws_ec2_application_load_balancer.sql")
-    } AS link; 
+        ${this.absoluteURL("/fleetfolio/aws_ec2_application_load_balancer.sql")
+      } AS link; 
 
 
       --- Dsply Page Title
@@ -1478,9 +1625,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
 
       SELECT
         $service AS title,
-        ${
-      this.absoluteURL("/fleetfolio/aws_cost_report.sql?service=")
-    } || $service  AS link; 
+        ${this.absoluteURL("/fleetfolio/aws_cost_report.sql?service=")
+      } || $service  AS link; 
 
       --- Dsply Page Title
       SELECT
@@ -1510,13 +1656,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         amortized_cost_amount AS "amortized cost amount", 
         usage_quantity_amount AS "usage quantity amount"
         FROM ${viewNameDailyCost} WHERE service=$service AND ($tab = 'daily_cost' OR $tab IS NULL) ORDER BY period_start DESC;
-         ${
-      paginationDailyCost.renderSimpleMarkdown(
+         ${paginationDailyCost.renderSimpleMarkdown(
         "tab",
         "service",
         "$tab='daily_cost'",
       )
-    };
+      };
 
     -- AWS monthly service cost list    
     ${paginationMonthlyCost.init()} 
@@ -1529,13 +1674,12 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         amortized_cost_amount AS "amortized cost amount", 
         usage_quantity_amount AS "usage quantity amount"
         FROM ${viewNameMonthlyCost} WHERE service=$service AND $tab = 'monthly_coste' ORDER BY period_start DESC;
-         ${
-      paginationMonthlyCost.renderSimpleMarkdown(
+         ${paginationMonthlyCost.renderSimpleMarkdown(
         "tab",
         "service",
         "$tab='monthly_coste'",
       )
-    };
+      };
     `;
   }
 
@@ -1567,9 +1711,8 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
 
       SELECT
         'AWS Monthely Cost Summary' AS title,
-        ${
-      this.absoluteURL("/fleetfolio/aws_monthely_cost_detail_list.sql")
-    } AS link; 
+        ${this.absoluteURL("/fleetfolio/aws_monthely_cost_detail_list.sql")
+      } AS link; 
 
 
       --- Dsply Page Title


### PR DESCRIPTION

**Overview**
We wanted to replace the static tab interface with a dynamic, searchable dropdown to improve discoverability and maintain the existing auto-submit behavior.

**Initial State**

* The form used a hard‑coded set of tabs for view selection.
* No search/filter capability; all 12 options were listed vertically.

**Changes Attempted**

1. Swapped `<ul>` tabs for a `<select>` element.
2. Tried native `<datalist>` for filtering—ran into inconsistent browser support.
3. Experimented with CSS flex and grid layouts for horizontal alignment.
4. Integrated TomSelect for a fully searchable dropdown widget.

**Technical Challenges**

* SQLPage’s form-rendering logic adds deep-nested wrappers, making CSS overrides tricky.
* TomSelect’s default inline styles conflicted with our grid setup, requiring `!important` hacks.

**Final Implementation Status**

* ✅ Tabs converted to a TomSelect‑powered, searchable dropdown
* ✅ Robust search and filter functionality in all modern browsers
* ✅ Auto-submit behavior preserved on selection change
* ✅ All 12 view options retained in the new component
* ❌ Horizontal alignment: dropdown and submit button remain stacked vertically despite multiple CSS approaches

**Code Structure Changes**

* Moved tab markup into a `<select>` inside the existing form `<fieldset>`.
* Created a small CSS utility class for `min-width` on the dropdown.
* Updated form wrapper to use Bootstrap flex utilities for attempted inline layout.


