### PR TITLE
feat: add PostgreSQL Process Inventory to host detail view #355

### DIFF
--- a/lib/service/fleetfolio/stateful.sql
+++ b/lib/service/fleetfolio/stateful.sql
@@ -737,3 +737,20 @@ WHERE
     json_valid(content) = 1 
     AND name = "Osquery MySQL Process Inventory" 
     AND uri = "osquery-ms:query-result";
+
+-- Inventory: List PostgreSQL database processes
+-- ur_transform_list_postgresql_process_inventory
+DROP TABLE IF EXISTS ur_transform_list_postgresql_process_inventory;
+CREATE TABLE ur_transform_list_postgresql_process_inventory AS
+SELECT 
+    uniform_resource_id,
+    json_extract(content, '$.name') AS name,
+    json_extract(content, '$.hostIdentifier') AS host_identifier,
+    json_extract(content, '$.columns.name') AS process_name,
+    json_extract(content, '$.columns.path') AS process_path,
+    uri AS query_uri
+FROM uniform_resource 
+WHERE 
+    json_valid(content) = 1 
+    AND name = "Osquery PostgreSQL Process Inventory" 
+    AND uri = "osquery-ms:query-result";

--- a/lib/service/fleetfolio/stateless.sql
+++ b/lib/service/fleetfolio/stateless.sql
@@ -498,10 +498,20 @@ FROM ur_transform_list_cron_backup_jobs;
 
 DROP VIEW IF EXISTS list_mysql_process_inventory;
 CREATE VIEW list_mysql_process_inventory AS
-SELECT 
+SELECT
   host_identifier,
   name,
   process_name,
   process_path,
   query_uri
 FROM ur_transform_list_mysql_process_inventory;
+
+DROP VIEW IF EXISTS list_postgresql_process_inventory;
+CREATE VIEW list_postgresql_process_inventory AS
+SELECT
+  host_identifier,
+  name,
+  process_name,
+  process_path,
+  query_uri
+FROM ur_transform_list_postgresql_process_inventory;


### PR DESCRIPTION
- Added PostgreSQL Process Inventory as a new dropdown option in the host detail interface
- Implemented PostgreSQL process monitoring using osQuery
- Enabled pagination, search, and sorting for process data
- Integrated data source attribution and responsive UI components