### PR TITLE
fix: make page-body full width in qualityfolio #355

### DIFF
--- a/lib/service/qualityfolio/package.sql.ts
+++ b/lib/service/qualityfolio/package.sql.ts
@@ -1437,7 +1437,7 @@ WHERE rn.id = $id;
 
               <!-- Page Wrapper -->
               <div class="page-wrapper">
-                  <main class="page-body container-xl flex-grow-1 px-md-5 px-sm-3 {{#if fixed_top_menu}}mt-5{{#unless (eq layout 'boxed')}} pt-5{{/unless}}{{else}} mt-3{{/if}}" id="sqlpage_main_wrapper">
+                  <main class="page-body w-full container-xl flex-grow-1 px-md-5 px-sm-3 {{#if fixed_top_menu}}mt-5{{#unless (eq layout 'boxed')}} pt-5{{/unless}}{{else}} mt-3{{/if}}" id="sqlpage_main_wrapper">
                       {{~#each_row~}}{{~/each_row~}}
                   </main>
               </div>


### PR DESCRIPTION
Updated the `<main>` element's class in qualityfolio to ensure the page body spans the full width of its container.

**Changes:**

Added w-full to the page-body class to fix layout issues where the page wasn't utilizing full available width.

*Old:*

`<main class="page-body container-xl flex-grow-1 px-md-5 px-sm-3 {{#if fixed_top_menu}}mt-5{{#unless (eq layout 'boxed')}} pt-5{{/unless}}{{else}} mt-3{{/if}}" id="sqlpage_main_wrapper">`

_New:_

`<main class="page-body w-full container-xl flex-grow-1 px-md-5 px-sm-3 {{#if fixed_top_menu}}mt-5{{#unless (eq layout 'boxed')}} pt-5{{/unless}}{{else}} mt-3{{/if}}" id="sqlpage_main_wrapper">`

**Reason:**
Adding w-full ensures consistent full-width behavior, resolving layout alignment issues observed in certain viewports.