### PR TITLE
refactor: simplify main layout container in qualityfolio #355

### DIFF
--- a/lib/service/qualityfolio/package.sql.ts
+++ b/lib/service/qualityfolio/package.sql.ts
@@ -1437,7 +1437,7 @@ WHERE rn.id = $id;
 
               <!-- Page Wrapper -->
               <div class="page-wrapper">
-                  <main class="page-body w-full container-xl flex-grow-1 px-md-5 px-sm-3 {{#if fixed_top_menu}}mt-5{{#unless (eq layout 'boxed')}} pt-5{{/unless}}{{else}} mt-3{{/if}}" id="sqlpage_main_wrapper">
+                  <main class="page-body w-full flex-grow-1 px-0" id="sqlpage_main_wrapper">
                       {{~#each_row~}}{{~/each_row~}}
                   </main>
               </div>


### PR DESCRIPTION
### Summary
This PR simplifies the `<main>` tag layout in `qualityfolio` by reducing the number of utility classes and conditional Handlebars expressions.

### Changes
- Removed `container-xl`, `px-md-5`, `px-sm-3`, and complex Handlebars conditionals related to spacing.
- Updated to a cleaner, more maintainable layout:
  ```html
  <main class="page-body w-full flex-grow-1 px-0" id="sqlpage_main_wrapper">
