### PR TITLE
fix: sort TAP results by title in qualityfolio and show all options in fleetfolio #355

### DIFF
--- a/lib/service/fleetfolio/package.sql.ts
+++ b/lib/service/fleetfolio/package.sql.ts
@@ -625,73 +625,34 @@ export class FleetFolioSqlPages extends spn.TypicalSqlPageNotebook {
         SELECT 'hidden' AS type, 'host_identifier' AS name, $host_identifier AS value;
 
         -- Searchable dropdown select field with all view options
-        WITH
-          policy_count AS (
-              SELECT COUNT(*) AS datacount FROM ${policyViewName} WHERE host_identifier = $host_identifier
-          ),
-          software_count AS (
-              SELECT COUNT(*) AS datacount FROM ${softwareViewName} WHERE host_identifier = $host_identifier
-          ),
-          user_count AS (
-              SELECT COUNT(*) AS datacount FROM ${userListViewName} WHERE host_identifier = $host_identifier
-          ),
-          container_count AS (
-              SELECT COUNT(*) AS datacount FROM ${containerViewName} WHERE host_identifier = $host_identifier
-          ),
-          process_count AS (
-              SELECT COUNT(*) AS datacount FROM ${processViewName} WHERE host_identifier = $host_identifier
-          ),
-          asset_service_count AS (
-              SELECT COUNT(*) AS datacount FROM ${assetServiceViewName} WHERE host_identifier = $host_identifier
-          ),
-          tls_enabled_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listPorts443ViewName} WHERE host_identifier = $host_identifier
-          ),
-          ssl_cert_file_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listListSSLCertFile} WHERE host_identifier = $host_identifier
-          ),
-          ssl_cert_file_mtime_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listListSSLCertFileMtime} WHERE host_identifier = $host_identifier
-          ),
-          vpn_listening_ports_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listVpnListeningPorts} WHERE host_identifier = $host_identifier
-          ),
-          cron_backup_jobs_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listCronBackupJobs} WHERE host_identifier = $host_identifier
-          ),
-          mysql_process_inventory_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listMysqlProcessInventory} WHERE host_identifier = $host_identifier
-          ),
-          postgresql_process_inventory_count AS (
-              SELECT COUNT(*) AS datacount FROM ${listPostgresqlProcessInventory} WHERE host_identifier = $host_identifier
-          ),
-          options AS (
-              SELECT '{"value":"policies","label":"Policies"}' AS option FROM policy_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"software","label":"Software"}' FROM software_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"users","label":"Users"}' FROM user_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"container","label":"Containers"}' FROM container_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"all_process","label":"All Process"}' FROM process_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"asset_service","label":"Asset Service"}' FROM asset_service_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"ssl_tls_is_enabled","label":"SSL/TLS is enabled"}' FROM tls_enabled_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"osquery_ssl_cert_files","label":"SSL Certificate Files"}' FROM ssl_cert_file_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"ssl_certificate_and_key_file_modification_times","label":"SSL Certificate and Key File Modification Times"}' FROM ssl_cert_file_mtime_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"vpn_listening_ports","label":"VPN Listening Ports"}' FROM vpn_listening_ports_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"cron_backup_jobs","label":"Cron Jobs Related to Backup Tasks"}' FROM cron_backup_jobs_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"mysql_process_inventory","label":"MySQL Process Inventory"}' FROM mysql_process_inventory_count WHERE datacount > 0
-              UNION ALL SELECT '{"value":"postgresql_process_inventory","label":"PostgreSQL Process Inventory"}' FROM postgresql_process_inventory_count WHERE datacount > 0
-          )
 
+        -- Show all dropdown options, not just 4
+        WITH options AS (
+            SELECT '{"value":"policies","label":"Policies"}' AS option
+            UNION ALL SELECT '{"value":"software","label":"Software"}'
+            UNION ALL SELECT '{"value":"users","label":"Users"}'
+            UNION ALL SELECT '{"value":"container","label":"Containers"}'
+            UNION ALL SELECT '{"value":"all_process","label":"All Process"}'
+            UNION ALL SELECT '{"value":"asset_service","label":"Asset Service"}'
+            UNION ALL SELECT '{"value":"ssl_tls_is_enabled","label":"SSL/TLS is enabled"}'
+            UNION ALL SELECT '{"value":"osquery_ssl_cert_files","label":"SSL Certificate Files"}'
+            UNION ALL SELECT '{"value":"ssl_certificate_and_key_file_modification_times","label":"SSL Certificate and Key File Modification Times"}'
+            UNION ALL SELECT '{"value":"vpn_listening_ports","label":"VPN Listening Ports"}'
+            UNION ALL SELECT '{"value":"cron_backup_jobs","label":"Cron Jobs Related to Backup Tasks"}'
+            UNION ALL SELECT '{"value":"mysql_process_inventory","label":"MySQL Process Inventory"}'
+            UNION ALL SELECT '{"value":"postgresql_process_inventory","label":"PostgreSQL Process Inventory"}'
+        )
 
-SELECT
-    'select' AS type,
-    'tab' AS name,
-    '' AS label,
-    COALESCE($tab, 'policies') AS value,
-    'Search views...' AS placeholder,
-    TRUE AS searchable,
-    'onchange="this.form.submit()"' AS attributes,
-    '[' || GROUP_CONCAT(option, ',') || ']' AS options
-FROM options;
+        SELECT
+            'select' AS type,
+            'tab' AS name,
+            '' AS label,
+            COALESCE($tab, 'policies') AS value,
+            'Search views...' AS placeholder,
+            TRUE AS searchable,
+            'onchange="this.form.submit()"' AS attributes,
+            '[' || GROUP_CONCAT(option, ',') || ']' AS options
+        FROM options;
 
 
 

--- a/lib/service/qualityfolio/package.sql.ts
+++ b/lib/service/qualityfolio/package.sql.ts
@@ -1250,7 +1250,7 @@ SELECT
             ELSE 'rowClass-50'
         END as _sqlpage_css_class
     FROM html_test_execution_results
-    ORDER BY created_at DESC
+    ORDER BY test_report_name ASC
     LIMIT $limit OFFSET $offset;
 
     -- Pagination Controls (Bottom)


### PR DESCRIPTION
This PR introduces the following enhancements to improve usability and consistency across the platforms:

**Qualityfolio:**
TAP test result values are now ordered in ascending order based on the title field, improving readability and making result interpretation easier.

**Fleetfolio:**
Updated the UI to display all available options, ensuring comprehensive visibility and access for users during configuration or selection processes.