### PR TITLE
fix: resolve mismatch between total TAP test case count and displayed table entries #355

### DIFF
--- a/lib/service/qualityfolio/stateless.sql
+++ b/lib/service/qualityfolio/stateless.sql
@@ -417,7 +417,7 @@ WITH RECURSIVE tap_lines AS (
             ELSE ''
         END AS remaining_content
     FROM tap_lines
-    WHERE remaining_content != '' AND line_number < 300  -- Limit to prevent infinite recursion
+    WHERE remaining_content != ''
 ),
 parsed_test_lines AS (
     -- Parse TAP test lines to extract test components


### PR DESCRIPTION
**Problem:**
There was a mismatch between the total test case count displayed and the number of test cases shown in the TAP Results table in Qualityfolio. This led to confusion when reviewing test outcomes.

**Fix Implemented:**

1. Aligned the total test case count with the actual number of test cases rendered in the TAP Results table.

1. Ensured consistency between backend aggregation and frontend display logic.