### PR TITLE
feat: integrate whatweb and dnsx scan result pages with generalized schema and descriptions #586

### DIFF
--- a/lib/service/tem/README.md
+++ b/lib/service/tem/README.md
@@ -1,0 +1,228 @@
+# Opsfolio Threat Exposure Management (TEM)
+
+Security assessments are only as valuable as the actions they drive. Traditional penetration test reports often end up as static PDFs, spreadsheets, or siloed documents that are disconnected from day-to-day workflows. The result: delays in remediation, limited visibility for leadership, and compliance gaps when auditors ask for proof.
+
+Opsfolio Threat Exposure Management (TEM) solves this problem by providing a real-time, evidence-driven reporting and communications layer that transforms technical test results into actionable dashboards, workflows, and executive insights.
+
+Behind TEM, the Opsfolio Enterprise Assets Assessment (EAA) engine runs structured penetration testing and lightweight threat assessments. Together, Opsfolio EAA (engine) and Opsfolio TEM (experience) form the foundation for continuous threat exposure management, delivering actionable evidence directly into compliance and remediation workflows.
+
+- Opsfolio EAA provides the technical assessment engine.
+- Opsfolio TEM delivers the reporting, dashboards, and communications experience.
+
+Together, they feed directly into Opsfolio CaaS POA\&M workflows, ensuring every vulnerability is traceable, actionable, and tied to compliance obligations.
+
+With TEM and EAA, Opsfolio customers can move from static reports to continuous threat exposure management — improving security posture, reducing remediation delays, and achieving audit readiness faster.
+
+> Read [SQL vs. Mangle (Datalog) for Threat Exposure Querying](tem-queries.md) for advanced deductive reasoning ideas.
+
+## The Opsfolio Suite
+
+Opsfolio TEM and Opsfolio EAA are part of the Opsfolio Suite, which underpins Opsfolio Compliance-as-a-Service (CaaS) offerings.
+
+* Opsfolio EAA (Enterprise Assets Assessment)
+
+  * Runs the technical assessments (authorized penetration testing, asset discovery, lightweight red-team style probes).
+  * Produces structured artifacts (JSON, JSONL, XML, CSV, text) stored in Opsfolio’s evidence warehouse.
+  * Ingests outputs from both automated scanners and manual pentest workflows into a single system of record.
+
+* Opsfolio TEM (Threat Exposure Management)
+
+  * Provides the customer-facing UI/UX for exposure reporting, dashboards, and communication.
+  * Automates finding delivery, triage, and ticketing in real time.
+  * Powers executive dashboards that summarize exposures, risks, and remediation progress.
+  * Communicates directly with IT and DevOps teams via Jira, ServiceNow, Slack, or Teams.
+
+* Opsfolio CaaS (Compliance-as-a-Service)
+
+  * Uses TEM and EAA as core tools to generate Plans of Actions and Milestones (POA\&M/POAM) for regulated industries.
+  * Links threat assessment evidence directly to compliance frameworks (SOC2, ISO, CMMC, HIPAA, FedRAMP, etc.).
+  * Provides a continuous compliance pipeline that transforms security operations into audit-ready deliverables.
+
+## How Opsfolio TEM & EAA Work Together
+
+1. Ingest Evidence
+
+   * Opsfolio EAA executes authorized penetration testing workflows.
+   * All findings are normalized and stored in the evidence warehouse.
+
+2. Centralize & Correlate
+
+   * Surveilr-based ingestion pipelines structure results into SQL.
+   * Opsfolio TEM uses SQLPage dashboards to surface evidence consistently.
+
+3. Deliver & Automate
+
+   * TEM provides real-time dashboards showing vulnerabilities and exposures as soon as they’re found.
+   * Findings are automatically routed into IT workflows with standardized rules (severity, ownership, asset type).
+
+4. Remediate & Track
+
+   * Issues are tracked through the TEM remediation lifecycle (Open → In Progress → Remediated → Validated → Closed).
+   * TEM notifies stakeholders and ensures remediation progress is visible to both technical and leadership teams.
+
+5. Validate & Close the Loop
+
+   * When a POA\&M item is marked as remediated, TEM automatically triggers Opsfolio EAA retests to confirm closure.
+   * Results are logged and archived for compliance audits.
+
+## Customer Benefits
+
+* Real-Time Visibility – Dashboards show live findings, not stale reports.
+* Faster Remediation – Issues can be acted on as soon as they’re identified.
+* Standardized Workflows – Every finding follows a consistent lifecycle.
+* POA\&M Integration – Findings are automatically translated into POA\&M items, tracked through to resolution.
+* Compliance-Ready Evidence – All evidence is structured, mapped to controls, and tied to compliance obligations.
+* Multi-Tenant Capable – Opsfolio TEM supports MSPs/MSSPs delivering assessments across multiple customers.
+
+## Usage Examples
+
+* CISOs & Security Leaders
+  Use TEM dashboards to measure exposure trends, MTTR, and compliance posture across multiple environments.
+
+* DevOps & IT Operations
+  Receive EAA findings directly in Jira or ServiceNow via TEM automation, enabling quick fixes without switching tools.
+
+* Compliance & Audit Teams
+  Use TEM’s evidence mappings to generate POA\&M items automatically, ensuring remediation is tracked in compliance workflows.
+
+* Service Providers (MSPs/MSSPs)
+  Run Opsfolio EAA assessments across multiple customers and deliver standardized TEM dashboards for each tenant.
+
+## Implementation Roadmap (Phased)
+
+* Phase 1 – Foundations
+  Centralize EAA artifacts into TEM dashboards. Provide baseline evidence explorers and POA\&M export.
+
+* Phase 2 – Workflow Automation
+  Add real-time delivery, Jira/ServiceNow integrations, Slack/Teams notifications, and standardized remediation lifecycles.
+
+* Phase 3 – Advanced CTEM
+  Implement triggered retesting, exposure scoring, executive dashboards, and trend analytics. Integrate deeply into Opsfolio CaaS for continuous compliance.
+
+## Phased Implementation Plan
+
+The goal is to deliver a TEM Enterprise Assets Assessment (EAA) capability that matches (and eventually exceeds) the user experience and workflows demonstrated by industry standard tools, while building on our existing Surveilr → SQL ingestion pipeline and SQLPage UI.
+
+This plan breaks implementation into three phases to reduce complexity, deliver value early, and progressively add automation.
+
+* Phase 1: Centralize + visualize (start with Surveilr + SQLPage basics).
+* Phase 2: Automate workflows + integrate with Jira/ServiceNow + enable real-time updates.
+* Phase 3: Full CTEM maturity with retesting, exposure scoring, executive dashboards, and compliance integration.
+
+This phased roadmap ensures we deliver tangible value quickly while steadily moving toward a comprehensive Pentest Reporting & Threat Exposure Management platform that rivals industry standard tools within our Opsfolio CaaS ecosystem.
+
+### Phase 1 – Foundations
+
+Timeline: Immediate (1–2 months)
+Objective: Centralize evidence and findings, provide baseline reporting, and deliver a usable analyst UI.
+
+* Surveilr ingests tool outputs (Subfinder, dnsx, httpx, WhatWeb, Naabu, Nmap, OpenSSL, Nuclei, Katana, tlsx, etc.) directly into SQL tables.
+* SQLPage web server presents dashboards and evidence views from these SQL tables.
+* TEM UI/UX extended to include:
+
+  * Evidence Explorer: browse artifacts by tool, scope, or run ID.
+  * Findings Viewer: filter/search by domain, severity, asset.
+  * Runbook Log Viewer: view captured environment and arguments for traceability.
+* Analysts can use the Qualityfolio test management model for manual notes, triage, and tagging.
+
+Deliverable: A functioning TEM EAA portal where raw findings are structured, viewable, and exportable—no more static PDFs or spreadsheet-based analysis.
+
+### Phase 2 – Workflow Automation & Integrations
+
+Timeline: Near-term (3–6 months)
+Objective: Automate delivery and remediation workflows, reduce manual triage, and integrate with customer systems.
+
+* Add rules-based routing of findings:
+
+  * Auto-tag findings based on severity, asset type, or business unit.
+  * Route critical findings to Jira/ServiceNow via connectors.
+* Enable real-time delivery: as Surveilr ingests evidence, SQLPage dashboards update automatically.
+* Introduce remediation workflows:
+
+  * Analysts assign findings to owners.
+  * Track finding status (Open → In Progress → Remediated → Retested → Closed).
+* Add notifications: Slack/Teams/email integration for critical/high findings.
+* Begin integrating Opsfolio CaaS compliance mapping (link findings to SOC2, ISO, CMMC controls).
+
+Deliverable: A workflow-driven EAA UI with integrated ticketing, real-time delivery, and standardized remediation lifecycle.
+
+### Phase 3 – Advanced CTEM (Continuous Threat Exposure Management)
+
+Timeline: Mid-term (6–12 months)
+Objective: Build a complete Threat Exposure Management layer that goes beyond industry standard tools by leveraging Opsfolio’s compliance-driven architecture.
+
+* Add triggered retesting: when a Jira/ServiceNow issue is closed, automatically queue/run relevant EAA runbook tests and mark validation in TEM.
+* Introduce exposure scoring and trend analytics:
+
+  * Track MTTR, number of open findings by severity, remediation velocity.
+  * Show trends over time for individual clients and across the Opsfolio tenant base.
+* Provide executive dashboards: high-level summaries for leadership and auditors.
+* Enable multi-tenant reporting for MSP/MSSP models.
+* Expand Opsfolio CaaS integration: automatically produce compliance-ready evidence bundles.
+
+Deliverable: A mature CTEM-aligned EAA platform, with automation, analytics, and compliance baked into TEM/Opsfolio, exceeding industry standard tools' capabilities.
+
+### Capabilities Required
+
+| Capability             | Competitors Today                                                         | TEM EAA – Phase 1 (Foundations)                                     | TEM EAA – Phase 2 (Workflows & Integrations)                          | TEM EAA – Phase 3 (Advanced CTEM)                         |
+| -------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Data Ingestion         | Centralized ingestion of scanner + pentest findings into database | Surveilr ingestion → SQL tables, structured JSON/JSONL artifacts from runbooks | Live ingestion pipelines updating dashboards automatically                       | Exposure scoring + historical trend analysis across all tenants      |
+| Reporting              | Interactive dashboards, reports replacing static PDFs                      | SQLPage UI: Evidence explorer, Findings viewer, Runbook log viewer             | Customizable dashboards per domain/asset; Opsfolio compliance views              | Executive dashboards, compliance-ready evidence bundles              |
+| Workflow Automation    | Findings routed in real time via Workflow Automation Engine                | Manual triage via SQLPage/Qualityfolio tagging                                 | Rules-based routing by severity/asset; automated status workflow (Open → Closed) | Triggered retesting + validation workflows linked to ticket closures |
+| Ticketing Integration  | Jira/ServiceNow integration for auto-ticket creation                       | Not yet (manual export only)                                                   | Direct Jira/ServiceNow connectors; Slack/Teams/email notifications               | Closed-loop integration with ticketing for continuous remediation    |
+| Remediation Lifecycle  | Standardized workflows for triage → remediation → closure                  | Manual updates in Qualityfolio/SQL UI                                          | Full remediation workflows with ownership, SLA tracking                          | Retesting automation + continuous validation                         |
+| Validation / Retesting | Triggered retest when finding is resolved                                  | N/A                                                                            | N/A                                                                              | Automated retest & validation on ticket closure                      |
+| Analytics / Metrics    | MTTR, remediation velocity, exposure trending                              | Basic counts from SQL queries                                                  | MTTR + SLA dashboards; per-tenant KPIs                                           | Exposure scoring, trending across tenants; benchmarking              |
+| Multi-Tenant Support   | SaaS platform for service providers                                        | Single-tenant SQLPage instance                                                 | Limited multi-tenant by schema separation                                        | Full Opsfolio multi-tenant support (MSP/MSSP ready)                  |
+
+
+Once your databases ready, you can start the TEM web interface:
+
+```bash
+# Load the Console and TEM Web UI components
+deno run -A ./package.sql.ts | surveilr shell
+
+# Alternative method (equivalent to above)
+surveilr shell ./package.sql.ts
+
+# Start surveilr web UI in development mode with auto-reload
+SQLPAGE_SITE_PREFIX=/lib/service ../../std/surveilrctl.ts dev
+
+# Access the web interface
+# Main UI: http://localhost:9000/
+# Schema info: http://localhost:9000/dms/info-schema.sql
+```
+
+**Database File Management:**
+
+```bash
+# The working database after merge and rename
+resource-surveillance.sqlite.db
+
+# For archival purposes, you can rename with timestamps
+cp resource-surveillance.sqlite.db "resource-surveillance-$(date +%Y%m%d).sqlite.db"
+
+# Or organize by project/environment
+cp resource-surveillance.sqlite.db "tem-production-$(date +%Y%m%d).sqlite.db"
+```
+
+## Code Formatting and Linting
+
+To maintain consistent code quality and formatting across the TEM
+codebase:
+
+### Format Code
+
+```bash
+deno fmt  # Formats all TypeScript and JavaScript files
+```
+
+### Lint Code
+
+```bash
+deno lint  # Checks for code quality issues and potential bugs
+```
+
+**Note:** You may see warnings about unsupported compiler options (`baseUrl`,
+`paths`) when running `deno lint`. These warnings are expected and can be safely
+ignored as Deno uses its own module resolution system.

--- a/lib/service/tem/custom_shell.ts
+++ b/lib/service/tem/custom_shell.ts
@@ -1,0 +1,155 @@
+import * as spn from "../../std/notebook/sqlpage.ts";
+export class ShellSqlPages extends spn.TypicalSqlPageNotebook {
+  private title: string;
+  private logoImage: string;
+  private favIcon: string;
+  private hideHeaderTitle: boolean;
+
+  constructor(
+    title: string = "Resource Surveillance State Database (RSSD)",
+    logoImage: string = "surveilr-icon.png",
+    favIcon: string = "favicon.ico",
+    hideHeaderTitle: boolean = false,
+  ) {
+    super();
+    this.title = title;
+    this.logoImage = logoImage;
+    this.favIcon = favIcon;
+    this.hideHeaderTitle = hideHeaderTitle;
+  }
+
+  defaultShell() {
+    const shellConfig: Record<string, unknown> = {
+      component:
+        "case when sqlpage.environment_variable('EOH_INSTANCE')=1 then 'shell-custom' else 'shell' END",
+      title: this.hideHeaderTitle ? "" : this.title,
+      icon: "",
+      favicon: `https://www.surveilr.com/assets/brand/${this.favIcon}`,
+      image: `https://www.surveilr.com/assets/brand/${this.logoImage}`,
+      layout: "fluid",
+      fixed_top_menu: true,
+      link: "index.sql",
+      menu_item: [
+        { link: "index.sql", title: "Home" },
+      ],
+      javascript: this.hideHeaderTitle
+        ? [
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/sql.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/handlebars.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/json.min.js",
+          // Inline script to set browser tab title
+          `data:text/javascript,document.addEventListener('DOMContentLoaded',function(){document.title='${this.title}';});`,
+        ]
+        : [
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/sql.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/handlebars.min.js",
+          "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/languages/json.min.js",
+        ],
+      footer: `Resource Surveillance Web UI`,
+    };
+
+    // When hiding header title, add custom CSS to hide navbar title text
+    if (this.hideHeaderTitle) {
+      shellConfig.css = `
+        /* Hide all text content in navbar-brand except images */
+        .navbar-brand {
+          font-size: 0 !important;
+        }
+        .navbar-brand img {
+          font-size: initial !important;
+          display: inline-block !important;
+        }
+        /* Alternative approach - hide text nodes */
+        .navbar-brand > *:not(img) {
+          display: none !important;
+        }
+        /* Hide any span or text elements in navbar */
+        .navbar-brand span,
+        .navbar-brand .navbar-text {
+          display: none !important;
+        }
+      `;
+    }
+
+    return shellConfig;
+  }
+
+  @spn.shell({ eliminate: true })
+  "shell/shell.json"() {
+    return this.SQL`
+      ${JSON.stringify(this.defaultShell(), undefined, "  ")}
+    `;
+  }
+
+  @spn.shell({ eliminate: true })
+  "shell/shell.sql"() {
+    const literal = (value: unknown) =>
+      (typeof value === "number") ||
+        (typeof value === "string" &&
+          value.trim().toLowerCase().startsWith("case when"))
+        ? value
+        : value
+          ? this.emitCtx.sqlTextEmitOptions.quotedLiteral(value)[1]
+          : "NULL";
+    const selectNavMenuItems = (rootPath: string, caption: string) =>
+      `json_object(
+              'link', ${this.absoluteURL("")}||'${rootPath}',
+              'title', ${literal(caption)},
+              'submenu', (
+                  SELECT json_group_array(
+                      json_object(
+                          'title', title,
+                          'link', ${this.absoluteURL("/")}||link,
+                          'description', description
+                      )
+                  )
+                  FROM (
+                      SELECT
+                          COALESCE(abbreviated_caption, caption) as title,
+                          COALESCE(url, path) as link,
+                          description
+                      FROM sqlpage_aide_navigation
+                      WHERE namespace = 'prime' AND parent_path = '${rootPath}/index.sql'
+                      ORDER BY sibling_order
+                  )
+              )
+          ) as menu_item`;
+
+    const handlers = {
+      DEFAULT: (key: string, value: unknown) => `${literal(value)} AS ${key}`,
+      menu_item: (key: string, items: Record<string, unknown>[]) =>
+        items.map((item) => `${literal(JSON.stringify(item))} AS ${key}`),
+      javascript: (key: string, scripts: string[]) => {
+        const items = scripts.map((s) => `${literal(s)} AS ${key}`);
+        items.push(selectNavMenuItems("/docs/index.sql", "Docs"));
+        items.push(selectNavMenuItems("ur", "Uniform Resource"));
+        items.push(selectNavMenuItems("console", "Console"));
+        items.push(selectNavMenuItems("orchestration", "Orchestration"));
+        return items;
+      },
+      footer: () =>
+        // Dynamic SQL query to fetch the version directly in the footer
+        `'Surveilr '|| (SELECT json_extract(session_agent, '$.version') AS version FROM ur_ingest_session LIMIT 1) || ' Resource Surveillance Web UI (v' || sqlpage.version() || ') ' || ` +
+        `'📄 [' || substr(sqlpage.path(), 2) || '](' || ${this.absoluteURL("/console/sqlpage-files/sqlpage-file.sql?path=")
+        } || substr(sqlpage.path(), LENGTH(sqlpage.environment_variable('SQLPAGE_SITE_PREFIX')) + 2 ) || ')' as footer`,
+    };
+    const shell = this.defaultShell();
+    const sqlSelectExpr = Object.entries(shell).flatMap(([k, v]) => {
+      switch (k) {
+        case "menu_item":
+          return handlers.menu_item(k, v as Record<string, unknown>[]);
+        case "javascript":
+          return handlers.javascript(k, v as string[]);
+        case "footer":
+          return handlers.footer();
+        default:
+          return handlers.DEFAULT(k, v);
+      }
+    });
+    return this.SQL`
+      SELECT ${sqlSelectExpr.join(",\n       ")};
+    `;
+  }
+}

--- a/lib/service/tem/deps.ts
+++ b/lib/service/tem/deps.ts
@@ -1,0 +1,5 @@
+// local: ../../../../netspective-labs/sql-aide
+// remote: https://raw.githubusercontent.com/netspective-labs/sql-aide/v0.14.4
+
+export * from "../../std/deps.ts";
+export { sqlPageNB } from "../../std/notebook/mod.ts";

--- a/lib/service/tem/package.sql.ts
+++ b/lib/service/tem/package.sql.ts
@@ -1,0 +1,336 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-run --allow-sys
+import { sqlPageNB as spn } from "./deps.ts";
+import {
+    console as c,
+    docs as d,
+    orchestration as orch,
+    //shell as sh,
+    uniformResource as ur,
+} from "../../std/web-ui-content/mod.ts";
+import * as sh from "./custom_shell.ts";
+
+const WEB_UI_TITLE = "Tem";
+const WE_UI_LOGO = "tem.png";
+const WE_UI_FAV_ICON = "tem.ico";
+const HIDE_HEADER_TITLE = true; // Hide header title text since logo contains "Tem" text
+
+
+/**
+ * These pages depend on ../../std/package.sql.ts being loaded into RSSD (for nav).
+ *
+ * TODO: in TypicalSqlPageNotebook.SQL() call at the bottom of this code it
+ * probably makese sense to just add all dependent notebooks into the sources
+ * list like so:
+ *
+ *   TypicalSqlPageNotebook.SQL(new X(), new Y(), ..., new FhirSqlPages())
+ *
+ * where X, Y, etc. are in lib/std/content/mod.ts
+ */
+
+// custom decorator that makes navigation for this notebook type-safe
+function temNav(route: Omit<spn.RouteConfig, "path" | "parentPath">) {
+    return spn.navigationPrime({
+        ...route,
+        parentPath: "tem/index.sql",
+    });
+}
+
+/**
+ * These pages depend on ../../prime/ux.sql.ts being loaded into RSSD (for nav).
+ */
+
+export class TemSqlPages extends spn.TypicalSqlPageNotebook {
+    // TypicalSqlPageNotebook.SQL injects any method that ends with `DQL`, `DML`,
+    // or `DDL` as general SQL before doing any upserts into sqlpage_files.
+    navigationDML() {
+        return this.SQL`
+      -- delete all /tem-related entries and recreate them in case routes are changed
+      DELETE FROM sqlpage_aide_navigation WHERE parent_path like ${this.constructHomePath("tem")
+            };
+      ${this.upsertNavSQL(...Array.from(this.navigation.values()))}
+    `;
+    }
+
+    @spn.navigationPrimeTopLevel({
+        caption: "Tem",
+        description:
+            `Opsfolio TEM and Opsfolio EAA are part of the Opsfolio Suite, which underpins Opsfolio Compliance-as-a-Service (CaaS) offerings.`,
+    })
+    "tem/index.sql"() {
+        return this.SQL`
+    select
+        'text'              as component,
+        'Opsfolio Threat Exposure Management (TEM) transforms static penetration test reports into real-time, actionable dashboards and workflows. Powered by Opsfolio EAA, it streamlines vulnerability reporting, automates remediation tracking, and delivers compliance-ready evidence to keep your organization secure and audit-ready.' as contents;
+      WITH navigation_cte AS (
+          SELECT COALESCE(title, caption) as title, description
+            FROM sqlpage_aide_navigation
+           WHERE namespace = 'prime' AND path = ${this.constructHomePath("tem")
+            }
+      )
+      SELECT 'list' AS component, title, description
+        FROM navigation_cte;
+      SELECT caption as title, ${this.absoluteURL("/")
+            } || COALESCE(url, path) as link, description
+        FROM sqlpage_aide_navigation
+       WHERE namespace = 'prime' AND parent_path = ${this.constructHomePath("tem")
+            }
+       ORDER BY sibling_order;`;
+    }
+
+    @temNav({
+        caption: "Attack Surface Mapping",
+        description:
+            `This data represents the information footprint of an application, domain, or infrastructure, typically gathered during reconnaissance, vulnerability assessment, or penetration testing.`,
+        siblingOrder: 1,
+    })
+    "tem/attack_surface_mapping.sql"() {
+        return this.SQL`
+        ${this.activePageTitle()}
+
+        --- Dsply Page Title
+        SELECT
+            'title'   as component,
+            'Attack Surface Mapping ' contents;
+
+        SELECT
+            'text'              as component,
+            "Attack Surface Mapping is the process of identifying, collecting, and analyzing all potential points of entry an attacker could exploit within an organization's digital infrastructure. It involves using tools such as WhatWeb, Nmap, TLS/TLSX, Nuclei, DNSx, Dirsearch, Naabu, Subfinder, Katana, and HTTPX-Toolkit to enumerate exposed services, technologies, subdomains, directories, ports, TLS configurations, and vulnerabilities. This helps organizations gain a comprehensive view of their external and internal exposure, prioritize remediation efforts, and strengthen their security posture." as contents;
+
+        SELECT
+            'card' as component,
+            4      as columns;
+        SELECT
+            "Assets"  as title,
+            ${this.absoluteURL("/tem/eaa_asset.sql")}  as link;
+
+        SELECT "Findings" as title,
+            ${this.absoluteURL("/tem/eaa_finding.sql")}  as link;
+        `;
+    }
+
+    @spn.shell({ breadcrumbsFromNavStmts: "no" })
+    "tem/eaa_asset.sql"() {
+        return this.SQL`
+      ${this.activePageTitle()}
+        --- Display breadcrumb
+        SELECT
+            'breadcrumb' AS component;
+        SELECT
+            'Home' AS title,
+            ${this.absoluteURL("/")}    AS link;
+        SELECT
+            'Tem' AS title,
+            ${this.absoluteURL("/tem/index.sql")} AS link;  
+        SELECT 'Attack Surface Mapping' AS title,
+            ${this.absoluteURL("/tem/attack_surface_mapping.sql")} AS link;
+        SELECT 'Assets' AS title,
+            '#' AS link;
+
+        --- Dsply Page Title
+        SELECT
+          'title'   as component,
+          'Assets' as contents;
+
+        SELECT
+          'text'              as component,
+          'Collection of reconnaissance and security assessment tools used for subdomain discovery, port scanning, DNS probing, web technology fingerprinting, TLS analysis, and vulnerability detection.' as contents;
+        
+
+        SELECT 'table' AS component,
+       TRUE AS sort,
+       TRUE AS search;
+
+        SELECT
+            asset 
+        FROM list_eaa_asset;
+    `;
+    }
+
+    @spn.shell({ breadcrumbsFromNavStmts: "no" })
+    "tem/eaa_finding.sql"() {
+        return this.SQL`
+      ${this.activePageTitle()}
+        --- Display breadcrumb
+        SELECT
+            'breadcrumb' AS component;
+        SELECT
+            'Home' AS title,
+            ${this.absoluteURL("/")}    AS link;
+        SELECT
+            'Tem' AS title,
+            ${this.absoluteURL("/tem/index.sql")} AS link;  
+        SELECT 'Attack Surface Mapping' AS title,
+            ${this.absoluteURL("/tem/attack_surface_mapping.sql")} AS link;
+        SELECT 'Findings' AS title,
+            '#' AS link;
+
+        --- Dsply Page Title
+        SELECT
+          'title'   as component,
+          'Findings' as contents;
+
+        SELECT
+          'text'              as component,
+          'Detailed insights from each security tool, including scan results, fingerprints, DNS records, TLS details, subdomain enumeration, and vulnerability assessments, mapped per asset for better threat exposure analysis.' as contents;
+        
+
+        SELECT 'table' AS component,
+        TRUE AS sort,
+        TRUE AS search,
+        'Asset' as markdown;
+
+        SELECT
+             '[What web data]('||${this.absoluteURL("/tem/what_web.sql")
+            }||')' as Asset;
+        SELECT
+           '[DNSX Scan Results]('||${this.absoluteURL("/tem/dnsx.sql")
+            }||')' as Asset;
+    `;
+    }
+
+
+
+    @spn.shell({ breadcrumbsFromNavStmts: "no" })
+    "tem/what_web.sql"() {
+        const viewName = `list_what_web_data`;
+        const pagination = this.pagination({
+            tableOrViewName: viewName,
+            whereSQL: "",
+        });
+        return this.SQL`
+      ${this.activePageTitle()}
+        --- Display breadcrumb
+        SELECT
+            'breadcrumb' AS component;
+        SELECT
+            'Home' AS title,
+            ${this.absoluteURL("/")}    AS link;
+        SELECT
+            'Tem' AS title,
+            ${this.absoluteURL("/tem/index.sql")} AS link;  
+        SELECT 'Attack Surface Mapping' AS title,
+            ${this.absoluteURL("/tem/attack_surface_mapping.sql")} AS link;
+        SELECT 'Web Technology Fingerprinting' AS title,
+            '#' AS link;
+
+        --- Dsply Page Title
+        SELECT
+          'title'   as component,
+          'Web Technology Fingerprinting' as contents;
+
+        SELECT
+          'text'              as component,
+          'This page displays the results of automated web technology fingerprinting using WhatWeb. It includes details about detected servers, technologies, HTTP responses, geolocation, and key headers for each scanned endpoint.' as contents;
+        
+
+        SELECT 'table' AS component,
+       TRUE AS sort,
+       'http_status' AS markdown,
+       TRUE AS search;
+       
+        ${pagination.init()} 
+        SELECT
+            target_url AS "Target URL",
+        CASE
+                WHEN http_status BETWEEN 200 AND 299 THEN '🟢 ' || http_status
+                WHEN http_status BETWEEN 300 AND 399 THEN '🟠 ' || http_status
+                WHEN http_status BETWEEN 400 AND 599 THEN '🔴 ' || http_status
+            ELSE CAST(http_status AS TEXT)
+            END AS "HTTP Status",
+            ip_address AS "IP Address",
+            country AS "Country",
+            http_server AS "Web Server",
+            page_title AS "Detected Technologies",
+            uncommon_headers AS "Key HTTP Headers"
+        FROM ${viewName};
+        ${pagination.renderSimpleMarkdown()};
+    `;
+    }
+
+
+    @spn.shell({ breadcrumbsFromNavStmts: "no" })
+    "tem/dnsx.sql"() {
+        const viewName = `list_dnsx_data`;
+        const pagination = this.pagination({
+            tableOrViewName: viewName,
+            whereSQL: "",
+        });
+        return this.SQL`
+      ${this.activePageTitle()}
+        --- Display breadcrumb
+        SELECT
+            'breadcrumb' AS component;
+        SELECT
+            'Home' AS title,
+            ${this.absoluteURL("/")}    AS link;
+        SELECT
+            'Tem' AS title,
+            ${this.absoluteURL("/tem/index.sql")} AS link;  
+        SELECT 'Attack Surface Mapping' AS title,
+            ${this.absoluteURL("/tem/attack_surface_mapping.sql")} AS link;
+        SELECT 'DNS Enumeration Results' AS title,
+            '#' AS link;
+
+        --- Dsply Page Title
+        SELECT
+          'title'   as component,
+          'DNS Enumeration Results' as contents;
+
+        SELECT
+          'text'              as component,
+          'This page lists the discovered DNS records using dnsx. It provides information about resolved subdomains, their IP addresses, DNS servers queried, response status, and timestamps for when the enumeration was performed.' as contents;
+        
+
+        SELECT 'table' AS component,
+       TRUE AS sort,
+       TRUE AS search;
+
+        ${pagination.init()} 
+        SELECT
+            host,
+            ttl,
+            resolver,
+            ip_address as "ip address",
+            status_code AS "status code",
+            datetime(substr(timestamp, 1, 19), '-4 hours') AS time
+        FROM ${viewName};
+        ${pagination.renderSimpleMarkdown()};`;
+    }
+
+
+}
+
+export async function SQL() {
+    return await spn.TypicalSqlPageNotebook.SQL(
+        new class extends spn.TypicalSqlPageNotebook {
+            async statefulOsQeryMSSQL() {
+                // read the file from either local or remote (depending on location of this file)
+                return await spn.TypicalSqlPageNotebook.fetchText(
+                    import.meta.resolve("../../pattern/osquery-ms/stateful.sql"),
+                );
+            }
+            async statelessfleetfolioSQL() {
+                // read the file from either local or remote (depending on location of this file)
+                return await spn.TypicalSqlPageNotebook.fetchText(
+                    import.meta.resolve("./stateless.sql"),
+                );
+            }
+        }(),
+        new TemSqlPages(),
+        new c.ConsoleSqlPages(),
+        new d.DocsSqlPages(),
+        new ur.UniformResourceSqlPages(),
+        new orch.OrchestrationSqlPages(),
+        new sh.ShellSqlPages(
+            WEB_UI_TITLE,
+            WE_UI_LOGO,
+            WE_UI_FAV_ICON,
+            HIDE_HEADER_TITLE,
+        ),
+    );
+}
+
+// this will be used by any callers who want to serve it as a CLI with SDTOUT
+if (import.meta.main) {
+    console.log((await SQL()).join("\n"));
+}

--- a/lib/service/tem/stateless.sql
+++ b/lib/service/tem/stateless.sql
@@ -1,0 +1,116 @@
+-- This query extracts unique asset names from the `uniform_resource` table for URIs under `/var/`.
+-- It breaks down each URI into its path segments and applies the following rules:
+--   1. Identifies the base asset folder (e.g., ".session", "dnsx", "tls").
+--   2. Handles timestamp-like directories (e.g., "2025-09-06-01-53-35") by skipping them and using the next segment.
+--   3. Returns only distinct assets by grouping on the extracted asset name.
+--   4. Selects one representative URI (the lexicographically smallest via MIN(uri)) for each unique asset.
+--
+-- The result provides a deduplicated list of assets with a sample URI for each.
+DROP VIEW IF EXISTS list_eaa_asset;
+CREATE VIEW list_eaa_asset AS 
+WITH parts AS (
+  SELECT
+    uri,
+    -- remove query/fragments, trim slashes, then split into a JSON array of segments
+    '["' || REPLACE(
+      TRIM(
+        substr(uri, 1,
+          CASE
+            WHEN instr(uri, '?') > 0 THEN instr(uri, '?') - 1
+            WHEN instr(uri, '#') > 0 THEN instr(uri, '#') - 1
+            ELSE length(uri)
+          END
+        ), '/'
+      ),
+    '/', '","') || '"]' AS j
+  FROM uniform_resource
+  WHERE uri LIKE '%eaa%'
+),
+assets AS (
+  SELECT
+    uri,
+    j,
+    json_array_length(j) AS len,
+    json_extract(j, '$[' || (json_array_length(j) - 1) || ']') AS last_seg,
+    json_extract(j, '$[' || (json_array_length(j) - 2) || ']') AS penult_seg
+  FROM parts
+)
+SELECT
+  CASE
+    -- if the last segment looks like a file (has a dot), take the previous segment (the folder)
+    WHEN len >= 2 AND last_seg GLOB '*.*' THEN penult_seg
+    ELSE last_seg
+  END AS asset,
+  MIN(uri) AS uri
+FROM assets
+WHERE asset IS NOT NULL
+GROUP BY asset
+ORDER BY asset;
+
+
+-- This query extracts individual JSON-like segments enclosed in square brackets (e.g., [ ... ])
+-- from the `content` field of the `uniform_resource` table. It:
+-- 1. Cleans carriage returns and newlines from the content.
+-- 2. Recursively splits the content based on the '][' delimiter.
+-- 3. Returns each segment as a separate row along with its associated
+--    `ingest_session_id` and `uri`.
+-- The query filters rows where:
+--   - `nature` is "json"
+--   - `uri` matches the pattern "%whatweb/https___qa-sec-adminapp.pocn.com_443.json%"
+DROP VIEW IF EXISTS list_what_web_data_json;
+CREATE VIEW list_what_web_data_json AS
+WITH cleaned AS (
+  SELECT
+    uniform_resource_id,
+    uri,
+    TRIM(REPLACE(REPLACE(content, char(13), ''), char(10), '')) AS c
+  FROM uniform_resource
+  WHERE nature = 'json'
+    AND uri LIKE '%whatweb/%'
+    AND content LIKE '[%' -- ensure it starts with [
+)
+SELECT
+  c.uniform_resource_id,
+  c.uri,
+  json_each.value AS object
+FROM cleaned c,
+json_each(c.c)
+WHERE json_valid(c.c) = 1;
+
+-- Description:
+-- This view extracts key web metadata from JSON objects stored in 
+-- `list_what_web_data_json`.
+DROP VIEW IF EXISTS list_what_web_data;
+CREATE VIEW list_what_web_data AS
+SELECT
+    uniform_resource_id,
+    json_extract(object, '$.target') AS target_url,
+    json_extract(object, '$.http_status') AS http_status,
+    json_extract(object, '$.plugins.IP.string[0]') AS ip_address,
+    json_extract(object, '$.plugins.HTTPServer.string[0]') AS http_server,
+    json_extract(object, '$.plugins.Title.string[0]') AS page_title,
+    json_extract(object, '$.plugins.UncommonHeaders.string[0]') AS uncommon_headers,
+    json_extract(object, '$.plugins.Country.string[0]') AS country,
+    json_extract(object, '$.plugins.Country.module[0]') AS module,
+    json_extract(object, '$.plugins.Strict-Transport-Security.string[0]') AS strict_transport_security,
+    json_extract(object, '$.plugins.X-Frame-Options.string[0]') AS x_frame_options
+FROM list_what_web_data_json;
+
+-- View: list_dnsx_data
+-- This view extracts DNS resolution details from the `uniform_resource` table for records
+-- collected via DNSx scans. It filters JSONL data (`nature = 'jsonl'`) where the URI path
+-- includes '/dnsx/'. Extracted fields include hostnames, TTL values, resolvers, IP addresses,
+-- status codes, and timestamps.
+DROP VIEW IF EXISTS list_dnsx_data;
+CREATE VIEW list_dnsx_data AS
+SELECT
+    uniform_resource_id,
+    json_extract(content, '$.host') AS host,
+    json_extract(content, '$.ttl') AS ttl,
+    json_extract(content, '$.resolver[0]') AS resolver,
+    json_extract(content, '$.a[0]') AS ip_address,
+    json_extract(content, '$.status_code') AS status_code,
+    json_extract(content, '$.timestamp') AS timestamp
+FROM uniform_resource
+WHERE nature = 'jsonl'
+  AND uri LIKE '%/dnsx/%';


### PR DESCRIPTION
This update enhances the TEM (Threat Exposure Management) SQLPage by adding support for displaying web scan and DNS enumeration results from WhatWeb and dnsx.

### Changes
- Added a generalized schema for WhatWeb results including URL, status code, IP address, country, server software, detected technologies, and key HTTP headers.
- Added a generalized schema for dnsx results including domain, status code, resolver, IP address, DNS status, TTL, and timestamp.
- Introduced standardized titles and page descriptions:
  - **Web Technology Fingerprinting Results** for WhatWeb
  - **DNS Enumeration Results** for dnsx
- Ensured output pages are consistent, minimal, and reusable across different scans.

### Purpose
This enables security teams to:
- View reconnaissance data in a structured format.
- Perform quick assessments of web technologies and DNS records.
- Integrate scan outputs directly into the TEM dashboard for actionable insights.

### Impact
Improves visibility and consistency of reconnaissance data, aligning with the TEM reporting workflow.