### PR TITLE
add Nuclei scan results integration with structured sql view #586

### DIFF
--- a/lib/service/tem/package.sql.ts
+++ b/lib/service/tem/package.sql.ts
@@ -185,6 +185,9 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
         SELECT
            '[DNSX Scan Results]('||${this.absoluteURL("/tem/dnsx.sql")
             }||')' as Asset;
+        SELECT
+           '[Nuclei Scan Findings]('||${this.absoluteURL("/tem/nuclei.sql")
+            }||')' as Asset;
     `;
     }
 
@@ -297,6 +300,57 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
         ${pagination.renderSimpleMarkdown()};`;
     }
 
+
+    @spn.shell({ breadcrumbsFromNavStmts: "no" })
+    "tem/nuclei.sql"() {
+        const viewName = `list_nuclei_data`;
+        const pagination = this.pagination({
+            tableOrViewName: viewName,
+            whereSQL: "",
+        });
+        return this.SQL`
+      ${this.activePageTitle()}
+        --- Display breadcrumb
+        SELECT
+            'breadcrumb' AS component;
+        SELECT
+            'Home' AS title,
+            ${this.absoluteURL("/")}    AS link;
+        SELECT
+            'Tem' AS title,
+            ${this.absoluteURL("/tem/index.sql")} AS link;  
+        SELECT 'Attack Surface Mapping' AS title,
+            ${this.absoluteURL("/tem/attack_surface_mapping.sql")} AS link;
+        SELECT 'Nuclei Scan Findings' AS title,
+            '#' AS link;
+
+        --- Dsply Page Title
+        SELECT
+          'title'   as component,
+          'Nuclei Scan Findings' as contents;
+
+        SELECT
+          'text'              as component,
+          'Comprehensive overview of detected vulnerabilities and exposures from Nuclei scans. Displays host, URL, template details, severity levels, matched paths, and timestamps for quick analysis and remediation planning.' as contents;
+        
+
+        SELECT 'table' AS component,
+       TRUE AS sort,
+       TRUE AS search;
+
+        ${pagination.init()} 
+        SELECT
+            host,
+            url,
+            template_id AS "Template ID",
+            name AS "Description",
+            severity AS "Severity",
+            ip AS "IP Address",
+            matched_path  AS "Matched Path",
+            datetime(substr(timestamp, 1, 19), '-4 hours') AS "Scan Time"
+        FROM ${viewName};
+        ${pagination.renderSimpleMarkdown()};`;
+    }
 
 }
 

--- a/lib/service/tem/stateless.sql
+++ b/lib/service/tem/stateless.sql
@@ -114,3 +114,22 @@ SELECT
 FROM uniform_resource
 WHERE nature = 'jsonl'
   AND uri LIKE '%/dnsx/%';
+
+-- View: list_nuclei_data
+-- Purpose: Extracts essential fields from Nuclei scan JSONL data stored in the uniform_resource table.
+-- Includes host, URL, template details, description, severity, IP, matched path, and timestamp.
+-- Filters only JSONL records under URIs containing "/nuclei/".
+DROP VIEW IF EXISTS list_nuclei_data;
+CREATE VIEW list_nuclei_data AS
+SELECT
+  json_extract(content, '$.host') AS host,
+  json_extract(content, '$.url') AS url,
+  json_extract(content, '$.template-id') AS template_id,
+  json_extract(content, '$.info.name') AS name,
+  json_extract(content, '$.info.description') AS description,
+  json_extract(content, '$.info.severity') AS severity,
+  json_extract(content, '$.ip') AS ip,
+  json_extract(content, '$.meta.paths') AS matched_path,
+  json_extract(content, '$.timestamp') AS timestamp
+FROM uniform_resource
+WHERE nature = 'jsonl' AND uri LIKE '%/nuclei/%';


### PR DESCRIPTION
### Summary
Integrated Nuclei vulnerability scanner results into TEM by creating a dedicated SQL view (`list_nuclei_data`). This enables displaying scan findings with key metadata including host, URL, template ID, severity, and timestamp.

### Changes
- Added SQL view to extract and normalize Nuclei JSONL results.
- Mapped key fields: host, URL, template ID, finding name, description, severity, IP, matched path, and scan timestamp.
- Prepared user-friendly column titles for table display.

### Impact
This enhancement provides better visibility into detected exposures and vulnerabilities, aligning Nuclei results with the existing TEM reporting structure.
