### PR TITLE
fix: update Compliance Explorer regime links to use absoluteURL #355

### DIFF
--- a/lib/pattern/compliance-explorer/package.sql.ts
+++ b/lib/pattern/compliance-explorer/package.sql.ts
@@ -55,12 +55,12 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
     SELECT
       'Secure Controls Framework (SCF)' AS title,
       'Explore SCF Controls' AS description_md,
-      '/ce/regime/scf.sql' AS link
+       ${this.absoluteURL("/ce/regime/scf.sql",)} AS link
     UNION
     SELECT
       'AICPA SOC 2' AS title,
       'Explore SOC 2 Controls' AS description_md,
-      '/ce/regime/soc2.sql' AS link;
+       ${this.absoluteURL("/ce/regime/soc2.sql",)} AS link
   `;
   }
 
@@ -88,11 +88,10 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       '**Health Insurance Portability and Accountability Act (HIPAA)**' || '  \n' ||
       '**Version:** ' || version || '  \n' ||
       '**Published/Last Reviewed Date/Year:** ' || last_reviewed_date || '  \n' ||
-      '[**Detail View**](' || ${
-      this.absoluteURL(
-        "/ce/regime/controls.sql?regimeType=US%20HIPAA",
-      )
-    }|| ')' AS description_md
+      '[**Detail View**](' || ${this.absoluteURL(
+      "/ce/regime/controls.sql?regimeType=US%20HIPAA",
+    )
+      }|| ')' AS description_md
     FROM compliance_regime
     WHERE title = 'US HIPAA';
 
@@ -103,11 +102,10 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       '**Standard 800-53 rev4**' || '  \n' ||
       '**Version:** ' || version || '  \n' ||
       '**Published/Last Reviewed Date/Year:** ' || last_reviewed_date || '  \n' ||
-      '[**Detail View**](' || ${
-      this.absoluteURL(
+      '[**Detail View**](' || ${this.absoluteURL(
         "/ce/regime/controls.sql?regimeType=NIST",
       )
-    } || ')' AS description_md
+      } || ')' AS description_md
     FROM compliance_regime
     WHERE title = 'NIST';`;
   }
@@ -162,11 +160,10 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       TRUE AS sort,
       TRUE AS search,
       "Control Code" AS markdown;
-      SELECT '[' || control_code || ']('|| ${
-      this.absoluteURL(
-        "/ce/regime/control/control_detail.sql?id=",
-      )
-    } || control_code || '&regimeType='|| replace($regimeType,
+      SELECT '[' || control_code || ']('|| ${this.absoluteURL(
+      "/ce/regime/control/control_detail.sql?id=",
+    )
+      } || control_code || '&regimeType='|| replace($regimeType,
     " ", "%20")||')' AS "Control Code",
       scf_control AS "Title",
       scf_domain AS "Domain",


### PR DESCRIPTION



#### **Summary**

This PR updates the `ce/index.sql` navigation configuration for the **Compliance Explorer** to use `this.absoluteURL()` for regime links.

#### **Changes Made**

* Replaced relative links:

  * `/ce/regime/scf.sql` → `this.absoluteURL("/ce/regime/scf.sql")`
  * `/ce/regime/soc2.sql` → `this.absoluteURL("/ce/regime/soc2.sql")`
* Ensures links resolve correctly in all environments and remain consistent with other navigation patterns.

#### **Why**

* Relative paths could cause incorrect routing depending on the current page location.
* Using `absoluteURL` standardizes link generation across the app, avoiding navigation issues.


