### PR TITLE
chore: add CMMC and HIPAA control detail pages

### DIFF
--- a/lib/pattern/compliance-explorer/package.sql.ts
+++ b/lib/pattern/compliance-explorer/package.sql.ts
@@ -53,11 +53,6 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       2 AS columns;
 
     SELECT
-      'Secure Controls Framework (SCF)' AS title,
-      'Explore SCF Controls' AS description_md,
-      ${this.absoluteURL("/ce/regime/scf.sql")} as link
-    UNION
-    SELECT
       'CMMC' AS title,
       'Explore CMMC Controls' AS description_md,
       ${this.absoluteURL("/ce/regime/cmmc.sql")} as link
@@ -115,9 +110,8 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       '**Version:** ' || version || '  \n' ||
       '**Published/Last Reviewed Date/Year:** ' || last_reviewed_date || '  \n' ||
       '[**Detail View**](' || ${this.absoluteURL(
-      "/ce/regime/controls.sql?regimeType=US%20HIPAA",
-    )
-      }|| ')' AS description_md
+        "/ce/regime/controls.sql?regimeType=US%20HIPAA",
+      )}|| ')' AS description_md
     FROM compliance_regime
     WHERE title = 'US HIPAA';
 
@@ -167,12 +161,12 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
     SELECT
       'SOC 2 Type I' AS title,
       'Report on Controls as a Service Organization. Relevant to Security, Availability, Processing Integrity, Confidentiality, or Privacy.' AS description,
-      ${this.absoluteURL('/ce/regime/aicpa/soc2.sql')} AS link
+      ${this.absoluteURL("/ce/regime/aicpa/soc2.sql")} AS link
     UNION ALL
     SELECT
       'SOC 2 Type II' AS title,
       'SOC 2 Type II reports provide lists of Internal controls that are audited by an Independent third-party to show how well those controls are implemented and operating.' AS description,
-      ${this.absoluteURL('/ce/regime/aicpa/soc2_type2.sql')} AS link;
+      ${this.absoluteURL("/ce/regime/aicpa/soc2_type2.sql")} AS link;
  
   `;
   }
@@ -289,9 +283,8 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
       TRUE AS search,
       "Control Code" AS markdown;
       SELECT '[' || control_code || ']('|| ${this.absoluteURL(
-      "/ce/regime/control/control_detail.sql?id=",
-    )
-      } || control_code || '&regimeType='|| replace($regimeType,
+        "/ce/regime/control/control_detail.sql?id=",
+      )} || control_code || '&regimeType='|| replace($regimeType,
     " ", "%20")||')' AS "Control Code",
       scf_control AS "Title",
       scf_domain AS "Domain",
@@ -365,36 +358,91 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
   }
 
   @ceNav({
-    caption: "HIPAA Security Rule Safeguards",
-    description:
-      "HIPAA Security Rule safeguards and their mapping with SCF and FII IDs.",
+    caption: "HIPAA",
+    description: "HIPAA and their mapping with SCF and FII IDs.",
     siblingOrder: 5,
   })
   "ce/regime/hipaa_security_rule.sql"() {
+    const pagination = this.pagination({
+      tableOrViewName: "hipaa_security_rule_safeguards",
+    });
+
     return this.SQL`
-     ${this.activePageTitle()}
-     SELECT
+    ${this.activePageTitle()}
+ 
+    SELECT
       'text' AS component,
-      'HIPAA Security Rule Safeguards' AS title;
-
-     SELECT
-      'The HIPAA Security Rule safeguards define administrative, physical, and technical measures required to ensure the confidentiality, integrity, and availability of electronic protected health information (ePHI).' AS contents;
-
-     SELECT
+      'HIPAA' AS title;
+ 
+    SELECT
+      'The HIPAA define administrative, physical, and technical measures required to ensure the confidentiality, integrity, and availability of electronic protected health information (ePHI).' AS contents;
+ 
+    -- Pagination controls (top)
+    ${pagination.init()}
+ 
+    SELECT
       'table' AS component,
       TRUE AS sort,
-      TRUE AS search;
-
-     SELECT
-      id AS "ID",
+      TRUE AS search,
+      "Control Code" AS markdown;
+ 
+    SELECT
+      '[' || hipaa_security_rule_reference || '](' ||
+        ${this.absoluteURL(
+          "/ce/regime/hipaa_security_rule_detail.sql?id=",
+        )} || hipaa_security_rule_reference || ')' AS "Control Code",
       common_criteria AS "Common Criteria",
-      hipaa_security_rule_reference AS "HIPAA Security Rule Reference",
-      safeguard AS "Safeguard",
+      safeguard AS "Control Question",
       handled_by_nq AS "Handled by nQ",
       fii_id AS "FII ID",
       tenant_name AS "Tenant"
-     FROM hipaa_security_rule_safeguards;
-    `;
+    FROM hipaa_security_rule_safeguards
+    ORDER BY hipaa_security_rule_reference
+    LIMIT $limit OFFSET $offset;
+ 
+    -- Pagination controls (bottom)
+    ${pagination.renderSimpleMarkdown()}
+  `;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "ce/regime/hipaa_security_rule_detail.sql"() {
+    return this.SQL`
+    SELECT
+      'breadcrumb' AS component;
+ 
+    SELECT
+      'Home' AS title,
+      ${this.absoluteURL("/")} AS link;
+ 
+    SELECT
+      'Controls' AS title,
+      ${this.absoluteURL("/ce/index.sql")} AS link;
+ 
+    SELECT
+      'HIPAA' AS title,
+      ${this.absoluteURL("/ce/regime/hipaa_security_rule.sql")} AS link;
+ 
+    -- Dynamic last breadcrumb using the reference from the DB
+    SELECT
+      hipaa_security_rule_reference AS title,
+      '#' AS link
+    FROM hipaa_security_rule_safeguards
+    WHERE hipaa_security_rule_reference = $id::TEXT;
+ 
+    SELECT
+      'card' AS component,
+      'HIPAA Security Rule Detail' AS title,
+      1 AS columns;
+ 
+    SELECT
+      common_criteria AS title,
+      '**Control Code:** ' || hipaa_security_rule_reference || '  \n\n' ||
+      '**Control Question:** ' || safeguard || '  \n\n' ||
+      '**FII ID:** ' || fii_id || '  \n\n'  AS description_md
+    FROM hipaa_security_rule_safeguards
+    WHERE hipaa_security_rule_reference = $id::TEXT;
+  `;
   }
 
   @ceNav({
@@ -435,71 +483,159 @@ export class ComplianceExplorerSqlPages extends spn.TypicalSqlPageNotebook {
   @ceNav({
     caption: "CMMC",
     description:
-      "Cybersecurity Maturity Model Certification (CMMC) Levels 1–3.",
+      "Cybersecurity Maturity Model Certification (CMMC) Levels 1-3.",
     siblingOrder: 6,
   })
   "ce/regime/cmmc.sql"() {
     return this.SQL`
     ${this.activePageTitle()}
-    SELECT 'text' AS component, 'CMMC Framework' AS title;
+    SELECT 'text' AS component, 'Cybersecurity Maturity Model Certification (CMMC)' AS title;
 
     SELECT
-      'The Cybersecurity Maturity Model Certification (CMMC) includes Levels 1, 2, and 3. Each level defines a set of practices and processes aligned with NIST standards.' AS contents;
+      "The Cybersecurity Maturity Model Certification (CMMC) program aligns with the information security requirements of the U.S. Department of Defense (DoD) for Defense Industrial Base (DIB) partners. The DoD has mandated that all organizations engaged in business with them, irrespective of size, industry, or level of involvement, undergo a cybersecurity maturity assessment based on the CMMC framework. This initiative aims to ensure the protection of sensitive unclassified information shared between the Department and its contractors and subcontractors. The program enhances the Department's confidence that contractors and subcontractors adhere to cybersecurity requirements applicable to acquisition programs and systems handling controlled unclassified information" AS contents;
 
     SELECT 'card' AS component, '' AS title, 3 AS columns;
 
     SELECT
-      'CMMC Level 1' AS title,
-      'Basic safeguarding of Federal Contract Information (FCI).' AS description_md,
+      'CMMC Model 2.0 LEVEL 1' AS title,
+      '15 requirements; Annual self-assessment & annual affirmation. The Department views Level 1 as an opportunity to engage its contractors in developing and strengthening their approach to cybersecurity. Self-assessments will suffice to meet CMMC Level 1 requirements. Contractors will be required to conduct self-assessment on an annual basis, accompanied by an annual affirmation from a senior company official that the company is meeting requirements. The Department intends to require companies to register self-assessments and affirmations in the Supplier Performance Risk System (SPRS).' AS description_md,
       ${this.absoluteURL("/ce/regime/cmmc_level.sql?level=1")} AS link
     UNION
     SELECT
-      'CMMC Level 2',
-      'Intermediate cyber hygiene aligned with NIST SP 800-171.',
+      'CMMC Model 2.0 LEVEL 2',
+      '110 requirements aligned with NIST SP 800-171; Triennial third-party assessment & annual affirmation; Triennial self-assessment & annual affirmation for select programs. A subset of programs with Level 2 requirements do not involve information critical to national security, and associated contractors will be permitted to meet the requirement through self-assessments. Contractors will be required to conduct self-assessment on an annual basis, accompanied by an annual affirmation from a senior company official that the company is meeting requirements. The Department intends to require companies to register self-assessments and affirmations in the Supplier Performance Risk System (SPRS).',
       ${this.absoluteURL("/ce/regime/cmmc_level.sql?level=2")}
     UNION
     SELECT
-      'CMMC Level 3',
-      'Expert level practices with enhanced NIST SP 800-171A requirements.',
+      'CMMC Model 2.0 LEVEL 3',
+      '110+ requirements based on NIST SP 800-171 & 800-172; Triennial government-led assessment & annual affirmation. The Department intends for Level 3 cybersecurity requirements to be assessed by government officials. Assessment requirements are currently under development. Level 3 information will likewise be posted as it becomes available.',
       ${this.absoluteURL("/ce/regime/cmmc_level.sql?level=3")};
   `;
   }
 
   @spn.shell({ breadcrumbsFromNavStmts: "no" })
   "ce/regime/cmmc_level.sql"() {
+    // Define pagination
+    const pagination = this.pagination({
+      tableOrViewName: "scf_view",
+      // Only fetch rows for the selected CMMC level
+      whereSQL: `
+      WHERE 
+        (@level = 1 AND cmmc_level_1 IS NOT NULL AND cmmc_level_1 != '')
+     OR (@level = 2 AND cmmc_level_2 IS NOT NULL AND cmmc_level_2 != '')
+     OR (@level = 3 AND cmmc_level_3 IS NOT NULL AND cmmc_level_3 != '')
+    `,
+    });
+
     return this.SQL`
+    ${this.activePageTitle()}
+
     --- Breadcrumbs
     SELECT 'breadcrumb' AS component;
     SELECT 'Home' AS title, ${this.absoluteURL("/")} AS link;
     SELECT 'Controls' AS title, ${this.absoluteURL("/ce/index.sql")} AS link;
-    SELECT 'CMMC' AS title, ${this.absoluteURL("/ce/regime/cmmc_index.sql")} AS link;
-    SELECT 'CMMC Level ' || level AS title
-    FROM (SELECT :level AS level) AS t;
-
+    SELECT 'CMMC' AS title, ${this.absoluteURL("/ce/regime/cmmc.sql")} AS link;
+    SELECT 'CMMC Level ' || COALESCE(@level::TEXT,'') AS title, '#' AS link;
 
     --- Description text
     SELECT 'text' AS component,
-           'The Cybersecurity Maturity Model Certification (CMMC) defines cybersecurity practices across Levels 1–3. Below are the mapped SCF controls for the selected level.' AS contents;
+       "The Cybersecurity Maturity Model Certification (CMMC) program aligns with the information security requirements of the U.S. Department of Defense (DoD) for Defense Industrial Base (DIB) partners. The DoD has mandated that all organizations engaged in business with them, irrespective of size, industry, or level of involvement, undergo a cybersecurity maturity assessment based on the CMMC framework. This initiative aims to ensure the protection of sensitive unclassified information shared between the Department and its contractors and subcontractors. The program enhances the Department's confidence that contractors and subcontractors adhere to cybersecurity requirements applicable to acquisition programs and systems handling controlled unclassified information" AS contents;
 
-    --- Table
-    SELECT 'table' AS component, TRUE AS sort, TRUE AS search;
-    SELECT 
-        scf_domain,
-        scf_control,
-        control_code,
-        CASE 
-          WHEN @level = 1 THEN cmmc_level_1
-          WHEN @level = 2 THEN cmmc_level_2
-          WHEN @level = 3 THEN cmmc_level_3
-        END AS cmmc_code,
-        control_description,
-        control_question
+
+    --- Table (markdown column)
+    SELECT 'table' AS component, TRUE AS sort, TRUE AS search, "Control Code" AS markdown;
+
+    -- Pagination Controls (Top)
+    ${pagination.init()}
+
+    --- Table data
+    SELECT
+      '[' || replace(replace(
+          CASE 
+            WHEN @level = 1 THEN cmmc_level_1
+            WHEN @level = 2 THEN cmmc_level_2
+            ELSE cmmc_level_3
+          END,
+          '\n', ' '),
+          '\r', ' ')
+      || '](' || ${this.absoluteURL("/ce/regime/cmmc_detail.sql?code=")}
+      || replace(replace(
+          CASE 
+            WHEN @level = 1 THEN cmmc_level_1
+            WHEN @level = 2 THEN cmmc_level_2
+            ELSE cmmc_level_3
+          END,
+          '\n', ' '), ' ', '%20')
+      || '&level=' || @level || ')' AS "Control Code",
+
+      scf_domain       AS "Domain",
+      scf_control      AS "Title",
+      control_code     AS "SCF Code",
+      control_description AS "Control Description",
+      control_question AS "Question"
+
     FROM scf_view
     WHERE 
-        (@level = 1 AND cmmc_level_1 IS NOT NULL AND cmmc_level_1 != '')
-     OR (@level = 2 AND cmmc_level_2 IS NOT NULL AND cmmc_level_2 != '')
-     OR (@level = 3 AND cmmc_level_3 IS NOT NULL AND cmmc_level_3 != '');
+          (@level = 1 AND cmmc_level_1 IS NOT NULL AND cmmc_level_1 != '')
+      OR (@level = 2 AND cmmc_level_2 IS NOT NULL AND cmmc_level_2 != '')
+      OR (@level = 3 AND cmmc_level_3 IS NOT NULL AND cmmc_level_3 != '')
+    ORDER BY control_code
+    LIMIT $limit OFFSET $offset;
+
+    -- Pagination Controls (Bottom)
+    ${pagination.renderSimpleMarkdown("level")};
   `;
+  }
+
+  @spn.shell({ breadcrumbsFromNavStmts: "no" })
+  "ce/regime/cmmc_detail.sql"() {
+    return this.SQL`
+    ${this.activePageTitle()}
+    --- Breadcrumbs
+    SELECT 'breadcrumb' AS component;
+    SELECT 'Home' AS title, ${this.absoluteURL("/")} AS link;
+    SELECT 'Controls' AS title, ${this.absoluteURL("/ce/index.sql")} AS link;
+    SELECT 'CMMC' AS title, ${this.absoluteURL("/ce/regime/cmmc.sql")} AS link;
+    SELECT 'CMMC Level ' || COALESCE($level::TEXT, '') AS title, ${this.absoluteURL("/ce/regime/cmmc_level.sql?level=")} || COALESCE($level::TEXT,'1') AS link;
+    SELECT COALESCE($code, '') AS title, '#' AS link;;
+
+    --- Primary details card
+    SELECT 'card' AS component, 'CMMC Control Details' AS title, 1 AS columns;
+    SELECT
+        COALESCE($code, '(unknown)') AS title,
+        '**Control Question:** ' || COALESCE(control_question, '') || '  \n\n' ||
+        '**Control Description:** ' || COALESCE(control_description, '') || '  \n\n' ||
+        '**SCF Domain:** ' || COALESCE(scf_domain, '') || '  \n\n' ||
+        '**SCF Control:** ' || COALESCE(scf_control, '') || '  \n\n' ||
+        '**SCF / FII IDs:** ' || COALESCE(control_code, '') AS description_md
+    FROM scf_view
+    WHERE
+          ($level = 1 AND replace(replace(cmmc_level_1,'\n',' '),'\\r','') = $code)
+      OR ($level = 2 AND replace(replace(cmmc_level_2,'\n',' '),'\\r','') = $code)
+      OR ($level = 3 AND replace(replace(cmmc_level_3,'\n',' '),'\\r','') = $code)
+    LIMIT 1;
+
+    --- Fallback if no exact match
+    SELECT 'text' AS component,
+          'No exact control found for code: ' || COALESCE($code,'(empty)') || '. Showing a fallback example for Level ' || COALESCE($level::TEXT,'1') || '.' AS contents
+    WHERE NOT EXISTS (
+        SELECT 1 FROM scf_view
+        WHERE
+              ($level = 1 AND replace(replace(cmmc_level_1,'\n',' '),'\\r','') = $code)
+          OR ($level = 2 AND replace(replace(cmmc_level_2,'\n',' '),'\\r','') = $code)
+          OR ($level = 3 AND replace(replace(cmmc_level_3,'\n',' '),'\\r','') = $code)
+    );
+
+    --- Example fallback card (optional)
+    SELECT 'card' AS component, 'Fallback control' AS title, 1 AS columns
+    WHERE NOT EXISTS (
+        SELECT 1 FROM scf_view
+        WHERE
+              ($level = 1 AND replace(replace(cmmc_level_1,'\n',' '),'\\r','') = $code)
+          OR ($level = 2 AND replace(replace(cmmc_level_2,'\n',' '),'\\r','') = $code)
+          OR ($level = 3 AND replace(replace(cmmc_level_3,'\n',' '),'\\r','') = $code)
+    );
+      `;
   }
 
   @spn.shell({ breadcrumbsFromNavStmts: "no" })


### PR DESCRIPTION
This PR introduces the following enhancements to the Compliance Controls module:

1. **CMMC Control Detail Pages**  
   - Added detail pages for CMMC Level 1, 2, and 3 controls.  
   - Properly render multi-line CMMC codes as clickable links.  
   - Display control question, description, SCF domain, SCF control, and SCF IDs (FII IDs) on the detail page.  

2. **HIPAA Control Detail Pages**  
   - Added detail pages for HIPAA Security Rule controls.  
   - Display full control information including question, description, domain, and control mappings.

3. **Listing Page Pagination**  
   - Added pagination for CMMC control listing pages using SQLPage’s built-in pagination helper.  
   - Supports `$limit` and `$offset` automatically, with pagination controls rendered at top and bottom.  

4. **Breadcrumb Improvements**  
   - Fixed breadcrumbs to correctly display the current level for CMMC listing pages.  
   - Made the last breadcrumb in detail pages non-clickable (`#`) to prevent unnecessary navigation.

