### PR TITLE
feat: changed session and tenant pages from card view to table listing #586

### DIFF
--- a/lib/service/tem/package.sql.ts
+++ b/lib/service/tem/package.sql.ts
@@ -124,13 +124,19 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
             'text'              as component,
             "This page presents the attack surface data collected during a specific session. It consolidates results from scanning and reconnaissance tools, showing discovered hosts, services, protocols, and exposed endpoints. This allows users to analyze session-specific findings, track changes over time, and prioritize security actions based on session-based activities." as contents;
 
-        SELECT
-            'card' as component,
-            4      as columns;
-        SELECT
-            session_date  as title,
-            ${this.absoluteURL("/tem/session/finding.sql?session_id=")} || ur_ingest_session_id  as link
-            FROM tem_session;
+        SELECT 'table' AS component,
+        TRUE AS sort,
+        TRUE AS search,
+        'Session' as markdown;
+
+        SELECT 
+            '[' || session_name || ']('||${this.absoluteURL("/tem/session/finding.sql?session_id=")} || ur_ingest_session_id || ')' AS "Session",
+            IFNULL(tools_count, '-') AS "Analysis Tools",
+            IFNULL(ingest_started_at, '-') AS "Session Start Date",
+            IFNULL(ingest_finished_at, '-') AS "Session End Date",
+            IFNULL(agent, '-') AS "Agent",
+            IFNULL(version, '-') AS "Version"
+        FROM tem_session;
         `;
     }
 
@@ -252,28 +258,41 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
 
         SELECT
              '[What web data]('||${this.absoluteURL("/tem/session/what_web.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+           (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+           (SELECT count(uniform_resource_id) FROM tem_what_web_result WHERE ur_ingest_session_id = $session_id) as "count";
         SELECT
            '[DNSX Scan Results]('||${this.absoluteURL("/tem/session/dnsx.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+           (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+           (SELECT count(uniform_resource_id) FROM tem_dnsx_result WHERE ur_ingest_session_id = $session_id) as "count";
         SELECT
            '[Nuclei Scan Findings]('||${this.absoluteURL("/tem/session/nuclei.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+            (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+            (SELECT count(uniform_resource_id) FROM tem_nuclei_result WHERE ur_ingest_session_id = $session_id) as "count";
         SELECT
            '[Naabu Port Scan Results]('||${this.absoluteURL("/tem/session/naabu.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+            (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+            (SELECT count(uniform_resource_id) FROM tem_naabu_result WHERE ur_ingest_session_id = $session_id) as "count";
         SELECT
            '[Subfinder Results]('||${this.absoluteURL("/tem/session/subfinder.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+            (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+            (SELECT count(uniform_resource_id) FROM tem_subfinder WHERE ur_ingest_session_id = $session_id) as "count";
          SELECT
            '[HTTPX Toolkit Results]('||${this.absoluteURL("/tem/session/httpx-toolkit.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+            (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+            (SELECT count(uniform_resource_id) FROM tem_httpx_result WHERE ur_ingest_session_id = $session_id) as "count";
          SELECT
            '[Nmap Scan Results]('||${this.absoluteURL("/tem/session/nmap.sql?session_id=")
-            } || $session_id || ')' as Asset;
+            } || $session_id || ')' as Asset,
+            (SELECT session_name FROM tem_session WHERE ur_ingest_session_id = $session_id) AS "Session Name",
+            (SELECT count(uniform_resource_id) FROM tem_nmap WHERE ur_ingest_session_id = $session_id) as "count";
     `;
     }
-
 
     @spn.shell({ breadcrumbsFromNavStmts: "no" })
     "tem/tenant/finding.sql"() {
@@ -312,29 +331,42 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
 
         SELECT
              '[What web data]('||${this.absoluteURL("/tem/tenant/what_web.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_what_web_result WHERE tenant_id = $tenant_id) as "count";
         SELECT
            '[DNSX Scan Results]('||${this.absoluteURL("/tem/tenant/dnsx.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_dnsx_result WHERE tenant_id = $tenant_id) as "count";
+            
         SELECT
            '[Nuclei Scan Findings]('||${this.absoluteURL("/tem/tenant/nuclei.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_nuclei_result WHERE tenant_id = $tenant_id) as "count";
         SELECT
            '[Naabu Port Scan Results]('||${this.absoluteURL("/tem/tenant/naabu.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_naabu_result WHERE tenant_id = $tenant_id) as "count";
         SELECT
            '[Subfinder Results]('||${this.absoluteURL("/tem/tenant/subfinder.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_subfinder WHERE tenant_id = $tenant_id) as "count";
          SELECT
            '[HTTPX Toolkit Results]('||${this.absoluteURL("/tem/tenant/httpx-toolkit.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_httpx_result WHERE tenant_id = $tenant_id) as "count";
          SELECT
            '[Nmap Scan Results]('||${this.absoluteURL("/tem/tenant/nmap.sql?tenant_id=")
-            } || $tenant_id || ')' as Asset;
+            } || $tenant_id || ')' as Asset,
+            (SELECT tanent_name FROM tem_tenant WHERE tenant_id = $tenant_id) AS "Tenant Name",
+            (SELECT count(uniform_resource_id) FROM tem_nmap WHERE tenant_id = $tenant_id) as "count";
     `;
     }
-
-
 
     @spn.shell({ breadcrumbsFromNavStmts: "no" })
     "tem/tenant/what_web.sql"() {
@@ -403,7 +435,6 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
         ${pagination.renderSimpleMarkdown("tenant_id")};
     `;
     }
-
 
     @spn.shell({ breadcrumbsFromNavStmts: "no" })
     "tem/session/what_web.sql"() {

--- a/lib/service/tem/stateless.sql
+++ b/lib/service/tem/stateless.sql
@@ -24,16 +24,17 @@ FROM organization org INNER JOIN device_party_relationship dpr ON dpr.party_id=o
 --   - behavior_json        : JSON configuration/behavior details
 -- Only active (non-deleted) sessions are included.
 -- ------------------------------------------------------------
-DROP VIEW IF EXISTS tem_ur_ingest_session;
 DROP VIEW IF EXISTS tem_session;
 CREATE VIEW tem_session AS
 SELECT
     ur_ingest_session_id,
     device_id,
-    ingest_started_at session_date,
-    ingest_finished_at,
-    session_agent,
-    behavior_json
+    strftime('%m-%d-%Y %H:%M:%S', ingest_started_at) AS session_name,
+    strftime('%m-%d-%Y %H:%M:%S', ingest_started_at) AS ingest_started_at,
+    strftime('%m-%d-%Y %H:%M:%S', ingest_finished_at) AS ingest_finished_at,
+    json_extract(session_agent, '$.agent') AS agent,
+    json_extract(session_agent, '$.version') AS version,
+    7 AS tools_count
 FROM ur_ingest_session
 WHERE deleted_at IS NULL;
 


### PR DESCRIPTION
This PR updates the UI for session and tenant pages and introduces a new findings page:

* **Session & Tenant Pages**

  * Replaced the previous card-based view with a **table listing**.
  * Each session now displays details such as session time, number of analysis tools executed, start and end dates, agent, and version.
  * Improved readability and sorting for better tracking of sessions.

* **Findings Page**

  * Added a new findings page under each session and tenant.
  * Displays results from multiple scanning and reconnaissance tools (e.g., What web data, DNSX, Nuclei, Naabu, Subfinder, HTTPX, Nmap).
  * Each finding is mapped with **session name** and **count of results**.
  * Provides consolidated insights for easier exposure analysis.

Screenshots attached show:

* **Attack Surface Mapping by Session** with tabular session listings.
* **Findings Page** with structured results per tool in a sortable table view.

This change improves usability by enabling easier navigation, sorting, and analysis of security findings.
