### PR TITLE
feat: add custom shell template #586

### DIFF
--- a/lib/service/tem/package.sql.ts
+++ b/lib/service/tem/package.sql.ts
@@ -2368,6 +2368,82 @@ export class TemSqlPages extends spn.TypicalSqlPageNotebook {
             ${ratingPagination.renderSimpleMarkdown("component", "tab", "uniform_resource_id", "session_id", "$tab='rating'")};
     `;
     }
+
+    @spn.shell({
+        breadcrumbsFromNavStmts: "no",
+        shellStmts: "do-not-include",
+        pageTitleFromNavStmts: "no",
+    })
+    "sqlpage/templates/shell-custom.handlebars"() {
+        return this.SQL`<!DOCTYPE html>
+          <html lang="{{language}}" style="font-size: {{default font_size 18}}px" {{#if class}} class="{{class}}" {{/if}}>
+            <head>
+            <meta charset="utf-8" />
+    
+              <!--Base CSS-->
+                <link rel="stylesheet" href="{{static_path 'sqlpage.css'}}">
+                  {{#each (to_array css)}}
+                  {{#if this}}
+    <link rel="stylesheet" href="{{this}}">
+      {{/if}}
+    {{/each}}
+    
+    <!--Font Setup-->
+      {{#if font}}
+    {{#if (starts_with font "/")}}
+    <style>
+      @font-face {
+      font-family: 'LocalFont';
+      src: url('{{font}}') format('woff2');
+      font-weight: normal;
+      font-style: normal;
+    }
+                          :root {
+      --tblr-font-sans-serif: 'LocalFont', Arial, sans-serif;
+    }
+    </style>
+    {{else}}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{font}}&display=fallback">
+          <style>
+                          :root {
+      --tblr-font-sans-serif: '{{font}}', Arial, sans-serif;
+    }
+    </style>
+    {{/if}}
+    {{/if}}
+    
+    <!--JavaScript-->
+      <script src="{{static_path 'sqlpage.js'}}" defer nonce="{{@csp_nonce}}"></script>
+    {{#each (to_array javascript)}}
+    {{#if this}}
+    <script src="{{this}}" defer nonce="{{@../csp_nonce}}"></script>
+    {{/if}}
+    {{/each}}
+    {{#each (to_array javascript_module)}}
+    {{#if this}}
+    <script src="{{this}}" type="module" defer nonce="{{@../csp_nonce}}"></script>
+    {{/if}}
+    {{/each}}
+    </head>
+    
+      <body class="layout-{{#if sidebar}}fluid{{else}}{{default layout 'boxed'}}{{/if}}" {{#if theme}} data-bs-theme="{{theme}}" {{/if}}>
+        <div class="page">
+          <!--Header-->
+    
+    
+            <!--Page Wrapper-->
+              <div class="page-wrapper">
+                <main class="page-body w-full flex-grow-1 px-0" id="sqlpage_main_wrapper">
+                  {{~#each_row~}}{{~/each_row~}}
+    </main>
+      </div>
+      </div>
+      </body>
+      </html>
+        `;
+    }
 }
 
 export async function SQL() {


### PR DESCRIPTION


### Summary

Added a custom SQLPage shell template (`shell-custom.handlebars`) to the **tem** package (`package.sql.ts`).

### Details

* Introduced `@spn.shell` configuration with the following options:

  * `breadcrumbsFromNavStmts: "no"`
  * `shellStmts: "do-not-include"`
  * `pageTitleFromNavStmts: "no"`
* Defined a custom HTML structure with:

  * Base CSS inclusion (`sqlpage.css` + dynamic CSS from `css` array).
  * Font handling with support for both local fonts and Google Fonts.
  * JavaScript setup (`sqlpage.js`, additional JS, and module scripts).
  * Configurable `<body>` layout (boxed or fluid) with theme support.
  * Page wrapper and main content structure bound to SQLPage row rendering.

### Purpose

This change allows the **tem** module to use a customized SQLPage shell template, giving more flexibility for styling, fonts, and scripts in rendered pages.
