### PR TITLE
chore: add views for CMMC, HIPAA, HITRUST, ISO27001, SOC2 controls

### DIFF
--- a/lib/pattern/compliance-explorer/stateful.sql
+++ b/lib/pattern/compliance-explorer/stateful.sql
@@ -1,58 +1,141 @@
 -- Drop the table if it exists, then create the new table with auto-increment primary key
 DROP TABLE IF EXISTS "compliance_regime";
 CREATE TABLE "compliance_regime" (
-    "compliance_regime_id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "title" TEXT NOT NULL,
-    "geography" TEXT,
-    "source" TEXT,
-    "description" TEXT,
-    "version" TEXT,
-    "last_reviewed_date" TIMESTAMPTZ,
-    "authoritative_source" TEXT,
-    "custom_user_text" TEXT,
-    "elaboration" TEXT CHECK(json_valid(elaboration) OR elaboration IS NULL),
-    "created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    "created_by" TEXT DEFAULT 'UNKNOWN',
-    "updated_at" TIMESTAMPTZ,
-    "updated_by" TEXT,
-    "deleted_at" TIMESTAMPTZ,
-    "deleted_by" TEXT,
-    "activity_log" TEXT
+"compliance_regime_id" INTEGER PRIMARY KEY AUTOINCREMENT,
+"title" TEXT NOT NULL,
+"geography" TEXT,
+"source" TEXT,
+"description" TEXT,
+"logo" TEXT,
+"status" TEXT,
+"version" TEXT,
+"last_reviewed_date" TIMESTAMPTZ,
+"authoritative_source" TEXT,
+"custom_user_text" TEXT,
+"elaboration" TEXT CHECK(json_valid(elaboration) OR elaboration IS NULL),
+"created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+"created_by" TEXT DEFAULT 'UNKNOWN',
+"updated_at" TIMESTAMPTZ,
+"updated_by" TEXT,
+"deleted_at" TIMESTAMPTZ,
+"deleted_by" TEXT,
+"activity_log" TEXT
 );
-
 -- Insert records into the table
 INSERT INTO "compliance_regime" (
-    "title",
-    "geography",
-    "source",
-    "description",
-    "version",
-    "last_reviewed_date",
-    "authoritative_source",
-    "custom_user_text"
+"title",
+"geography",
+"source",
+"description",
+"logo",
+"status",
+"version",
+"last_reviewed_date",
+"authoritative_source",
+"custom_user_text"
 )
 VALUES
-    (
-        'US HIPAA',
-        'US',
-        'Federal',
-        'The Health Insurance Portability and Accountability Act (HIPAA) Security Rule sets national standards to protect individuals electronic personal health information (ePHI) that is created, received, used, or maintained by a covered entity. The Security Rule mandates appropriate administrative, physical, and technical safeguards to ensure the confidentiality, integrity, and security of ePHI.' ||
-        'security, and integrity of protected health information (PHI), ensuring compliance for healthcare providers, ' ||
-        'insurers, and related entities handling electronic and physical health data',
-        'N/A',
-        '2022-10-20 00:00:00+00',
-        'Health Insurance Portability and Accountability Act (HIPAA)',
-        'Below, you will find a complete list of all controls applicable to the US HIPAA framework. These controls are designed ' ||
-        'to ensure compliance with the Health Insurance Portability and Accountability Act (HIPAA) standards, safeguarding ' ||
-        'sensitive patient health information'
-    ),
-    (
-        'NIST',
-        'Universal',
-        'SCF',
-        'The NIST SP 800-53 standard aims to protect operations, assets, individuals, organizations, and the United States from a wide range of cyber threats, including hostile attacks, human error, and natural disasters. The controls are designed to be flexible and customizable to support organizations in their implementation efforts.',
-        '2024',
-        '2024-04-01 00:00:00+00',
-        '800-53 rev4',
-        NULL
-    );
+(
+'HIPAA',
+'US',
+'Federal',
+'Health Insurance Portability and Accountability Act',
+'',
+'active',
+'N/A',
+'2022-10-20 00:00:00+00',
+'Health Insurance Portability and Accountability Act (HIPAA)',
+'Below, you will find a complete list of all controls applicable to the US HIPAA framework. These controls are designed ' ||
+'to ensure compliance with the Health Insurance Portability and Accountability Act (HIPAA) standards, safeguarding ' ||
+'sensitive patient health information'
+),
+(
+'NIST',
+'Universal',
+'SCF',
+'Comprehensive cybersecurity guidance framework',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),
+(
+'SOC2 Type I',
+'US',
+'SCF',
+'Report on Controls as a Service Organization. Relevant to Security, Availability, Processing Integrity, Confidentiality, or Privacy.',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'SOC2 Type II',
+'US',
+'SCF',
+'SOC 2 Type II reports provide lists of Internal controls that are audited by an Independent third-party to show how well those controls are implemented and operating.',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'HITRUST CSF',
+'US',
+'SCF',
+'Achieve HITRUST CSF certification, the most trusted and comprehensive security framework in healthcare.',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'CMMC Model 2.0 LEVEL 1',
+'US',
+'SCF',
+'Achieve Cybersecurity Maturity Model Certification (CMMC) to bid on Department of Defense contracts',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'CMMC Model 2.0 LEVEL 2',
+'US',
+'SCF',
+'110 requirements aligned with NIST SP 800-171; Triennial third-party assessment & annual affirmation; Triennial self-assessment & annual affirmation for select programs. A subset of programs with Level 2 requirements do not involve information critical to national security, and associated contractors will be permitted to meet the requirement through self-assessments. Contractors will be required to conduct self-assessment on an annual basis, accompanied by an annual affirmation from a senior company official that the company is meeting requirements. The Department intends to require companies to register self-assessments and affirmations in the Supplier Performance Risk System (SPRS).',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'CMMC Model 2.0 LEVEL 3',
+'US',
+'SCF',
+'110+ requirements based on NIST SP 800-171 & 800-172; Triennial government-led assessment & annual affirmation. The Department intends for Level 3 cybersecurity requirements to be assessed by government officials. Assessment requirements are currently under development. Level 3 information will likewise be posted as it becomes available.',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+),(
+'ISO 27001:2022',
+'US',
+'SCF',
+'Information security management systems standard',
+'',
+'active',
+'2024',
+'2024-04-01 00:00:00+00',
+'800-53 rev4',
+NULL
+);

--- a/lib/pattern/compliance-explorer/stateless.sql
+++ b/lib/pattern/compliance-explorer/stateless.sql
@@ -203,3 +203,270 @@ JOIN
 WHERE
   fs.file_basename LIKE '%.prompt.md'
   AND json_extract(ur.frontmatter, '$.regimeType') IS NOT NULL;;
+
+
+
+--###view for all controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS all_control;
+
+CREATE VIEW all_control AS
+    SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 1" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 1" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 1' AS control_type,
+    12 AS control_type_id,
+    6 AS control_compliance_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 1" != ''
+ 
+UNION ALL
+SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 2" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 2" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 2' AS control_type,
+    13 AS control_type_id,
+    7 AS control_compliance_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 2" != ''
+ 
+UNION ALL
+SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 3" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 3" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 3' AS control_type,
+    14 AS control_type_id,
+    8 AS control_compliance_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 3" != ''
+ 
+UNION ALL
+ 
+SELECT
+            CAST(cntl."#" AS INTEGER) AS display_order,
+            cntl."HIPAA Security Rule Reference" AS control_identifier,
+            cntl."HIPAA Security Rule Reference" AS control_code,
+            cntl."FII Id" AS fii,
+            cntl."Common Criteria" AS common_criteria,
+            '' AS expected_evidence,
+            cntl.Safeguard AS question,
+            'HIPAA' AS control_type,
+            0 AS control_type_id,
+            1 AS control_compliance_id        
+          FROM uniform_resource_hipaa_security_rule_safeguards cntl
+          
+UNION ALL
+SELECT
+            CAST(cntl."#" AS INTEGER) AS display_order,
+            cntl."Control Identifier" AS control_identifier,
+            cntl."Control Identifier" AS control_code,
+            cntl."Fii ID" AS fii,
+            cntl."Common Criteria" AS common_criteria,
+            cntl."Name" AS expected_evidence,
+            cntl.Description AS question,
+            'HITRUST' AS control_type,
+            0 AS control_type_id,
+            5 AS control_compliance_id  
+          FROM uniform_resource_hitrust_e1_assessment cntl
+          
+UNION ALL
+SELECT
+            (SELECT COUNT(*)
+            FROM uniform_resource_iso_27001_v3 AS sub
+            WHERE sub.ROWID <= cntl.ROWID) AS display_order,
+            'ISO-27001-' || (ROWID) as control_identifier,
+             cntl."SCF #" AS control_code,
+             cntl."SCF #" AS fii,
+             cntl."SCF Domain" AS common_criteria,
+             Evidence as expected_evidence,
+             cntl."SCF Control Question" AS question,
+             'ISO 27001:2022' AS control_type,
+            0 AS control_type_id,
+             9 AS control_compliance_id          
+        FROM uniform_resource_iso_27001_v3 as cntl
+UNION ALL
+SELECT
+        CAST(cntl."#" AS INTEGER) AS display_order,
+        cntl."Control Identifier" AS control_identifier,
+        cntl."Control Identifier" AS control_code,
+        cntl."Fii ID" AS fii,
+        cntl."Common Criteria" AS common_criteria,
+        cntl."Name" AS expected_evidence,
+        cntl."Questions Descriptions" AS question,
+        'SOC2 Type I' AS control_type,
+        2 AS control_type_id,
+        3 AS control_compliance_id
+    FROM uniform_resource_aicpa_soc2_controls cntl
+    UNION ALL
+    SELECT
+        CAST(cntl."#" AS INTEGER),
+        cntl."Control Identifier",
+        cntl."Control Identifier",
+        cntl."Fii ID",
+        cntl."Common Criteria",
+        cntl."Name",
+        cntl."Questions Descriptions",
+        'SOC2 Type II' AS control_type,
+        3 AS control_type_id,
+        4 AS control_compliance_id  
+    FROM uniform_resource_aicpa_soc2_type2_controls cntl;
+
+
+--###view for cmmc controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS cmmc_control;
+
+CREATE VIEW cmmc_control AS
+    SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 1" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 1" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 1' AS control_type,
+    12 AS control_type_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 1" != ''
+ 
+UNION ALL
+SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 2" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 2" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 2' AS control_type,
+    13 AS control_type_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 2" != ''
+ 
+UNION ALL
+SELECT
+    (SELECT COUNT(*)
+     FROM uniform_resource_scf_2024_2 AS sub
+     WHERE sub.ROWID <= cntl.ROWID
+       AND "US CMMC 2.0 Level 3" != '') AS display_order,
+    'CMMCLEVEL-' || ROWID AS control_identifier,
+    cntl."US CMMC 2.0 Level 3" AS control_code,
+    cntl."SCF #" AS fii,
+    cntl."SCF Domain" AS common_criteria,
+    '' AS expected_evidence,
+    cntl."SCF Control Question" AS question,
+    'CMMC Model 2.0 Level 3' AS control_type,
+    14 AS control_type_id
+FROM uniform_resource_scf_2024_2 AS cntl
+WHERE cntl."US CMMC 2.0 Level 3" != '';
+
+
+--###view for hipaa controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS hipaa_control;
+
+CREATE VIEW hipaa_control AS
+   SELECT
+            CAST(cntl."#" AS INTEGER) AS display_order,
+            cntl."HIPAA Security Rule Reference" AS control_identifier,
+            cntl."HIPAA Security Rule Reference" AS control_code,
+            cntl."FII Id" AS fii,
+            cntl."Common Criteria" AS common_criteria,
+            '' AS expected_evidence,
+            cntl.Safeguard AS question            
+          FROM uniform_resource_hipaa_security_rule_safeguards cntl;
+
+
+--###view for hitrust controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS hitrust_control;
+
+CREATE VIEW hitrust_control as
+SELECT
+            CAST(cntl."#" AS INTEGER) AS display_order,
+            cntl."Control Identifier" AS control_identifier,
+            cntl."Control Identifier" AS control_code,
+            cntl."Fii ID" AS fii,
+            cntl."Common Criteria" AS common_criteria,
+            cntl."Name" AS expected_evidence,
+            cntl.Description AS question
+          FROM uniform_resource_hitrust_e1_assessment cntl;
+
+
+--###view for iso27001 controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS iso27001_control;
+
+CREATE VIEW iso27001_control AS    
+SELECT
+            (SELECT COUNT(*)
+            FROM uniform_resource_iso_27001_v3 AS sub
+            WHERE sub.ROWID <= cntl.ROWID) AS display_order,
+            'ISO-27001-' || (ROWID) as control_identifier,
+             cntl."SCF #" AS control_code,
+             cntl."SCF #" AS fii,
+             cntl."SCF Domain" AS common_criteria,
+             Evidence as expected_evidence,
+             cntl."SCF Control Question" AS question            
+        FROM uniform_resource_iso_27001_v3 as cntl;
+
+
+--###view for soc2 controls details complaince explorer #####-------
+
+DROP VIEW IF EXISTS soc2_control;
+
+CREATE VIEW soc2_control AS
+    SELECT
+        CAST(cntl."#" AS INTEGER) AS display_order,
+        cntl."Control Identifier" AS control_identifier,
+        cntl."Control Identifier" AS control_code,
+        cntl."Fii ID" AS fii,
+        cntl."Common Criteria" AS common_criteria,
+        cntl."Name" AS expected_evidence,
+        cntl."Questions Descriptions" AS question,
+        'SOC2 Type I' AS control_type,
+        2 AS control_type_id
+    FROM uniform_resource_aicpa_soc2_controls cntl
+    UNION ALL
+    SELECT
+        CAST(cntl."#" AS INTEGER),
+        cntl."Control Identifier",
+        cntl."Control Identifier",
+        cntl."Fii ID",
+        cntl."Common Criteria",
+        cntl."Name",
+        cntl."Questions Descriptions",
+        'SOC2 Type II' AS control_type,
+        3 AS control_type_id
+    FROM uniform_resource_aicpa_soc2_type2_controls cntl;       


### PR DESCRIPTION

---

### PR Summary

* Added new SQL views for compliance controls (CMMC, HIPAA, HITRUST, ISO27001, SOC2) to enable detailed control exploration in Compliance Explorer.
* Each view includes control identifiers, codes, questions, evidence fields, and display order for structured retrieval.
* Updated compliance regime table to include additional fields and sample data to support expanded compliance frameworks.

---

