### PR TITLE
feat: spawn package.sql generator as background process and fix resource handling #654

### DIFF
--- a/lib/service/qualityfolio/eg.surveilr.com-prepare.ts
+++ b/lib/service/qualityfolio/eg.surveilr.com-prepare.ts
@@ -112,6 +112,60 @@ class App {
       // Step 2: Unzip the file
       await FileHandler.unzipFile(this.zipFilePath, ingestDir);
 
+      // Step 2.5: Generate package.sql in the rssd store without blocking this process.
+      try {
+        // Determine script directory (where package.sql.ts lives)
+        const scriptDir = dirname(path.fromFileUrl(import.meta.url));
+        // Place output package.sql inside the base rssd directory (same store)
+        const outputFile = path.join(this.ingestDir, '..', 'package.sql');
+        console.log(`Spawning background process to generate SQL (cwd=${scriptDir}), output=${outputFile}`);
+
+        // Open output file for writing (truncate/create)
+        const outFile = await Deno.open(outputFile, { create: true, write: true, truncate: true });
+
+        // Use Deno.Command to spawn the deno process and pipe stdout to the file.
+        const command = new Deno.Command('deno', {
+          args: ['run', '-A', './package.sql.ts'],
+          cwd: scriptDir,
+          stdout: 'piped',
+          stderr: 'piped',
+        });
+
+        const child = command.spawn();
+
+        // Pipe child's stdout to the output file asynchronously (do not await)
+        if (child.stdout) {
+          (async () => {
+            try {
+              await child.stdout.pipeTo(outFile.writable);
+            } catch (e) {
+              console.error('Error piping package.sql stdout:', e);
+            } finally {
+              // do not close outFile here: pipeTo will close the writable when complete
+            }
+          })();
+        } else {
+          // No stdout to pipe; close file silently
+          try { await outFile.close(); } catch (_) { /* ignore */ }
+        }
+
+        // Pipe child's stderr to the current process stderr for visibility (async)
+        if (child.stderr) {
+          (async () => {
+            try {
+              await child.stderr.pipeTo(Deno.stderr.writable);
+            } catch (e) {
+              console.error('Error piping package.sql stderr:', e);
+            }
+          })();
+        }
+
+        // Do not await child.status() so this runs in background relative to this script.
+      } catch (err) {
+        console.error('Failed to spawn package.sql generator:', err);
+        // don't throw — we don't want to stop the main flow if generation fails
+      }
+
       // Step 3: Execute the ingest command
       await CommandExecutor.executeCommand(this.ingestCommand);
     } catch (error: unknown) {


### PR DESCRIPTION
Body Spawn the package.sql generator from eg.surveilr.com-prepare.ts using Deno.Command so generation runs asynchronously and pipes stdout directly into the rssd store file. Replace deprecated Deno.run usage, pipe child stdout/stderr to appropriate destinations, and avoid double-closing the output file (fixes BadResource errors). Add logging around the spawn to help debugging.

- Use Deno.Command to run deno run -A ./package.sql.ts and pipe stdout -> rssd/package.sql.

- Pipe child's stderr to parent stderr so errors are visible.

- Avoid closing the file while pipeTo owns the writable (removed redundant close that caused BadResource).

- Keep main ingest flow non-blocking; child's status is not awaited by default.